### PR TITLE
fix: layout types name is duplicated with the class name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "graph layout algorithm",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/layout/layout.ts
+++ b/src/layout/layout.ts
@@ -18,7 +18,7 @@ import { ComboForceLayout } from './comboForce'
 export class Layout {
   public readonly layoutInstance: Base
 
-  constructor(options: Layout.LayoutOptions) {
+  constructor(options: ILayout.LayoutOptions) {
     const layoutClass = getLayoutByName(options.type)
     this.layoutInstance  = new layoutClass(options)
   }
@@ -27,7 +27,7 @@ export class Layout {
     return this.layoutInstance.layout(data)
   }
 
-  updateCfg(cfg: Layout.LayoutOptions) {
+  updateCfg(cfg: ILayout.LayoutOptions) {
     this.layoutInstance.updateCfg(cfg)
   }
 
@@ -60,7 +60,7 @@ export const Layouts: {[key: string]: any} = new Proxy({}, { // tslint:disable-l
   }
 })
 
-export namespace Layout {
+export namespace ILayout {
   registerLayout('grid', GridLayout)
   registerLayout('random', RandomLayout)
   registerLayout('force', ForceLayout)


### PR DESCRIPTION
fix: layout types name is duplicated with the class name