### PR TITLE
Allow filtering out nodes from the dagre layout run

### DIFF
--- a/src/layout/dagre.ts
+++ b/src/layout/dagre.ts
@@ -104,7 +104,7 @@ export class DagreLayout extends Base {
     g.setGraph(self);
 
     const comboMap: { [key: string]: boolean } = {};
-    nodes.forEach((node) => {
+    nodes.filter((node) => node.layout !== false).forEach((node) => {
       const size = nodeSizeFunc(node);
       const verti = vertisep(node);
       const hori = horisep(node);

--- a/src/layout/types.ts
+++ b/src/layout/types.ts
@@ -6,6 +6,7 @@ export interface OutNode extends Node {
   x: number;
   y: number;
   comboId?: string;
+  layout?: boolean
 }
 
 export interface Edge {


### PR DESCRIPTION
This allows for setting the property "layout" to the node model, and if it is set to false dagre will not be aware of the node when layouting. The node position can then be configured manually. If it is not set (i.e. null) the layout will render with the node. Only explicitly setting it to false will stop this from happening. Will add to G6 documentation if approved. 