### PR TITLE
fix(dagre)/stop-layout-nodes

### DIFF
--- a/src/layout/dagre.ts
+++ b/src/layout/dagre.ts
@@ -64,6 +64,17 @@ export class DagreLayout extends Base {
     };
   }
 
+  public layoutNode = (nodeId: string) => {
+    const self = this;
+    const { nodes } = self;
+    const node = nodes.find(node => node.id === nodeId);
+    if (node) {
+      const layout = node.layout !== false;
+      return layout;
+    }
+    return true;
+  }
+
   /**
    * 执行布局
    */
@@ -138,9 +149,11 @@ export class DagreLayout extends Base {
       // dagrejs Wiki https://github.com/dagrejs/dagre/wiki#configuring-the-layout
       const source = getEdgeTerminal(edge, 'source');
       const target = getEdgeTerminal(edge, 'target');
-      g.setEdge(source, target, {
-        weight: edge.weight || 1,
-      });
+      if (this.layoutNode(source) && this.layoutNode(target) {
+        g.setEdge(source, target, {
+          weight: edge.weight || 1,
+        });
+      }
     });
     dagre.layout(g);
     let coord;

--- a/src/layout/dagre.ts
+++ b/src/layout/dagre.ts
@@ -149,7 +149,7 @@ export class DagreLayout extends Base {
       // dagrejs Wiki https://github.com/dagrejs/dagre/wiki#configuring-the-layout
       const source = getEdgeTerminal(edge, 'source');
       const target = getEdgeTerminal(edge, 'target');
-      if (this.layoutNode(source) && this.layoutNode(target) {
+      if (this.layoutNode(source) && this.layoutNode(target)) {
         g.setEdge(source, target, {
           weight: edge.weight || 1,
         });


### PR DESCRIPTION
In my last PR I added this feature on the nodes, but I forgot to push the changes for the edges. 

This code checks if all the edges' source and targets are supposed to layout, and, except if layout is set to false on the node, it layouts the edge.

Without this there is undefined behavior as an edge attempts to point to a node that is not defined.