### PR TITLE
fix: make sure data order follow user inputs

### DIFF
--- a/__tests__/unit/dagreCompound.test.ts
+++ b/__tests__/unit/dagreCompound.test.ts
@@ -86,6 +86,8 @@ describe('#DagreCompoundLayout', () => {
             anchorPoint: true // 是否使用布局计算的锚点
         });
         dagreCompound.layout(data);
+        expect((data.nodes[1] as any).layoutOrder).toBe(1); // layoutOrder should be initialized
+        expect((data.nodes[2] as any).layoutOrder).toBe(2);
         expect((data.nodes[0] as any).x).not.toBe(undefined);
         expect((data.nodes[0] as any).y).not.toBe(undefined);
     });


### PR DESCRIPTION
> 内部添加排序属性，确保布局使用的数据与用户输入的数据顺序一致

layoutOrder 仅在首次布局或动态添加节点时复写，其余情况不变，这样根据 layoutOrder 排序后的数据与用户首次输入顺序保持一致，不会出现因数据顺序变化而影响布局结果。