### PR TITLE
fix: small width and height values for grid lead to 0 rows or cols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+#### 0.2.4
+
+- fix: small width and height values for grid lead to 0 rows or cols;
+
 #### 0.2.3
 
 - perf: combo and node info should be transfered to outerLayout in comboCombined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "graph layout algorithm",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/layout/grid.ts
+++ b/src/layout/grid.ts
@@ -191,6 +191,8 @@ export class GridLayout extends Base {
       self.rows = Math.round(self.splits);
       self.cols = Math.round((self.width / self.height) * self.splits);
     }
+    self.rows = Math.max(self.rows, 1);
+    self.cols = Math.max(self.cols, 1);
     if (self.cols * self.rows > self.cells) {
       // otherwise use the automatic values and adjust accordingly
       // if rounding was up, see if we can reduce rows or columns


### PR DESCRIPTION
fix: small width and height values for grid lead to 0 rows or cols