### PR TITLE
Remove console log line

### DIFF
--- a/src/util/gpu.ts
+++ b/src/util/gpu.ts
@@ -63,7 +63,6 @@ export const buildTextureData = (nodes: OutNode[], edges: Edge[]): {
     const offset: number = dataArray.length;
     const dests = nodeDict[i];
     const len = dests.length;
-    console.log('dests', dests, len)
     dataArray[i * 4 + 2] = offset;
     dataArray[i * 4 + 3] = len;
     maxEdgePerVetex = Math.max(maxEdgePerVetex, len);


### PR DESCRIPTION
Hi,

A recent update to how the GPU util has introduced a console log line that spams our console wherever we have GPU accelerated graphs.

We tracked it down to this line and propose the change to remove it as it probably was a debug line left by mistake