### PR TITLE
修改 gForce 的 calAttractive

### DIFF
--- a/src/layout/gForce.ts
+++ b/src/layout/gForce.ts
@@ -379,7 +379,7 @@ export class GForceLayout extends Base {
       const vecLength = Math.sqrt(vecX * vecX + vecY * vecY);
       const direX = vecX / vecLength;
       const direY = vecY / vecLength;
-      const length = (linkDistance as Function)(edge, sourceNode, targetNode) || 1 + ((nodeSize(sourceNode) + nodeSize(sourceNode)) || 0) / 2;
+      const length = (linkDistance as Function)(edge, sourceNode, targetNode) || 1 + ((nodeSize(sourceNode) + nodeSize(targetNode)) || 0) / 2;
       const diff = length - vecLength;
       const param = diff * (edgeStrength as Function)(edge);
       const sourceIdx = nodeIdxMap[source];


### PR DESCRIPTION
原来的：

`nodeSize(sourceNode) + nodeSize(sourceNode)`

不对称，我觉得应该是：

`nodeSize(sourceNode) + nodeSize(targetNode)`
