### PR TITLE
fix: use the latest g-webgpu package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g-webgpu": "0.7.0",
+    "@antv/g-webgpu": "0.7.1",
     "@antv/graphlib": "^1.0.0",
     "d3-force": "^2.1.1",
     "d3-quadtree": "^2.0.0",
@@ -51,7 +51,7 @@
     "ml-matrix": "^6.5.0"
   },
   "devDependencies": {
-    "@antv/g-webgpu-compiler": "0.7.0",
+    "@antv/g-webgpu-compiler": "0.7.1",
     "@antv/g6": "^4.0.3",
     "@babel/core": "*",
     "@babel/polyfill": "^7.12.1",


### PR DESCRIPTION
v0.3.8 仍然残留 `inversify` 等依赖：
https://bundlephobia.com/package/@antv/layout

<img width="1169" alt="截屏2022-11-29 下午2 29 33" src="https://user-images.githubusercontent.com/3608471/204455475-68e6d4df-fe6b-4492-842e-411a0788a0fa.png">

原因是 `g-webgpu` 依赖的 `core` 忘记修改到 `^0.7.0` 了，导致安装的还是旧版本。无其他功能修改。

发布 `v0.3.9` 后可以再验证下，应该完全去除相关依赖。