### PR TITLE
fix: remove unused export objects avoiding warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g-webgpu": "0.7.1",
+    "@antv/g-webgpu": "0.7.2",
     "@antv/graphlib": "^1.0.0",
     "d3-force": "^2.1.1",
     "d3-quadtree": "^2.0.0",
@@ -51,7 +51,7 @@
     "ml-matrix": "^6.5.0"
   },
   "devDependencies": {
-    "@antv/g-webgpu-compiler": "0.7.1",
+    "@antv/g-webgpu-compiler": "0.7.2",
     "@antv/g6": "^4.0.3",
     "@babel/core": "*",
     "@babel/polyfill": "^7.12.1",


### PR DESCRIPTION
移除了导致 warning 的类型