### PR TITLE
在 README.md 中增加 LayoutAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+<h1 align="center">
+<b>AntV Layout</b>
+</h1>
+
+[![Build Status](https://github.com/antvis/layout/workflows/build/badge.svg?branch=v5)](https://github.com/antvis//actions)
+[![Coverage Status](https://img.shields.io/coveralls/github/antvis/layout/v5.svg)](https://coveralls.io/github/antvis/layout?branch=v5)
+[![npm Download](https://img.shields.io/npm/dm/@antv/layout.svg)](https://www.npmjs.com/package/@antv/layout)
+[![npm License](https://img.shields.io/npm/l/@antv/layout.svg)](https://www.npmjs.com/package/@antv/layout)
+
+This is a collection of basic layout algorithms. We provide the following packages to support different runtime environments:
+
+- [@antv/layout](./packages/layout/README.md) [![npm Version](https://img.shields.io/npm/v/@antv/layout/alpha)](https://www.npmjs.com/package/@antv/layout) Implemented with TypeScript. [Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6)
+- [@antv/layout-rust](./packages/layout-rust/README.md) Implemented with Rust.
+- [@antv/layout-wasm](./packages/layout-wasm/README.md) [![npm Version](https://img.shields.io/npm/v/@antv/layout-wasm)](https://www.npmjs.com/package/@antv/layout-wasm) Provide a WASM binding of `@antv/layout-rust`. [Online Demo](https://observablehq.com/d/288c16a54543a141)
+- [@antv/layout-gpu](./packages/layout-gpu/README.md) Accelerate some parallelizable algorithms such as Fruchterman with WebGPU which has a better performance under large amount of data.

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This is a collection of basic layout algorithms. We provide the following packag
 - [@antv/layout](./packages/layout/README.md) [![npm Version](https://img.shields.io/npm/v/@antv/layout/alpha)](https://www.npmjs.com/package/@antv/layout) Implemented with TypeScript. [Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6)
 - [@antv/layout-rust](./packages/layout-rust/README.md) Implemented with Rust.
 - [@antv/layout-wasm](./packages/layout-wasm/README.md) [![npm Version](https://img.shields.io/npm/v/@antv/layout-wasm)](https://www.npmjs.com/package/@antv/layout-wasm) Provide a WASM binding of `@antv/layout-rust`. [Online Demo](https://observablehq.com/d/288c16a54543a141)
-- [@antv/layout-gpu](./packages/layout-gpu/README.md) Accelerate some parallelizable algorithms such as Fruchterman with WebGPU which has a better performance under large amount of data.
+- [@antv/layout-gpu](./packages/layout-gpu/README.md) [![npm Version](https://img.shields.io/npm/v/@antv/layout-gpu)](https://www.npmjs.com/package/@antv/layout-gpu) Accelerate some parallelizable algorithms such as Fruchterman with WebGPU which has a better performance under large amount of data.

--- a/demo/fruchterman.gpu.html
+++ b/demo/fruchterman.gpu.html
@@ -1,0 +1,1013 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,shrink-to-fit=no"
+    />
+    <title>Fruchterman GPU</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        height: 100%;
+      }
+
+      #container {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="container"></div>
+    <script
+      src="https://unpkg.com/@antv/g"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@antv/g-canvas"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@antv/g-plugin-dragndrop"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../packages/layout/dist/index.min.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../packages/layout-gpu/dist/index.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      const { Graph } = window.GraphLib;
+      const { FruchtermanLayout } = window.LayoutGPU;
+
+      const { Circle, Line, Canvas } = window.G;
+      // create a renderer
+      const canvasRenderer = new window.G.Canvas2D.Renderer();
+      const plugin = new window.G.Dragndrop.Plugin();
+      canvasRenderer.registerPlugin(plugin);
+      // create a canvas
+      const canvas = new Canvas({
+        container: "container",
+        width: 500,
+        height: 500,
+        renderer: canvasRenderer,
+      });
+
+      const data = {
+        nodes: [
+          {
+            id: "Argentina",
+            data: {
+              name: "Argentina",
+            },
+          },
+          {
+            id: "Australia",
+            data: {
+              name: "Australia",
+            },
+          },
+          {
+            id: "Belgium",
+            data: {
+              name: "Belgium",
+            },
+          },
+          {
+            id: "Brazil",
+            data: {
+              name: "Brazil",
+            },
+          },
+          {
+            id: "Colombia",
+            data: {
+              name: "Colombia",
+            },
+          },
+          {
+            id: "Costa Rica",
+            data: {
+              name: "Costa Rica",
+            },
+          },
+          {
+            id: "Croatia",
+            data: {
+              name: "Croatia",
+            },
+          },
+          {
+            id: "Denmark",
+            data: {
+              name: "Denmark",
+            },
+          },
+          {
+            id: "Egypt",
+            data: {
+              name: "Egypt",
+            },
+          },
+          {
+            id: "England",
+            data: {
+              name: "England",
+            },
+          },
+          {
+            id: "France",
+            data: {
+              name: "France",
+            },
+          },
+          {
+            id: "Germany",
+            data: {
+              name: "Germany",
+            },
+          },
+          {
+            id: "Iceland",
+            data: {
+              name: "Iceland",
+            },
+          },
+          {
+            id: "IR Iran",
+            data: {
+              name: "IR Iran",
+            },
+          },
+          {
+            id: "Japan",
+            data: {
+              name: "Japan",
+            },
+          },
+          {
+            id: "Korea Republic",
+            data: {
+              name: "Korea Republic",
+            },
+          },
+          {
+            id: "Mexico",
+            data: {
+              name: "Mexico",
+            },
+          },
+          {
+            id: "Morocco",
+            data: {
+              name: "Morocco",
+            },
+          },
+          {
+            id: "Nigeria",
+            data: {
+              name: "Nigeria",
+            },
+          },
+          {
+            id: "Panama",
+            data: {
+              name: "Panama",
+            },
+          },
+          {
+            id: "Peru",
+            data: {
+              name: "Peru",
+            },
+          },
+          {
+            id: "Poland",
+            data: {
+              name: "Poland",
+            },
+          },
+          {
+            id: "Portugal",
+            data: {
+              name: "Portugal",
+            },
+          },
+          {
+            id: "Russia",
+            data: {
+              name: "Russia",
+            },
+          },
+          {
+            id: "Saudi Arabia",
+            data: {
+              name: "Saudi Arabia",
+            },
+          },
+          {
+            id: "Senegal",
+            data: {
+              name: "Senegal",
+            },
+          },
+          {
+            id: "Serbia",
+            data: {
+              name: "Serbia",
+            },
+          },
+          {
+            id: "Spain",
+            data: {
+              name: "Spain",
+            },
+          },
+          {
+            id: "Sweden",
+            data: {
+              name: "Sweden",
+            },
+          },
+          {
+            id: "Switzerland",
+            data: {
+              name: "Switzerland",
+            },
+          },
+          {
+            id: "Tunisia",
+            data: {
+              name: "Tunisia",
+            },
+          },
+          {
+            id: "Uruguay",
+            data: {
+              name: "Uruguay",
+            },
+          },
+        ],
+        edges: [
+          {
+            id: "0",
+            target: "Russia",
+            source: "Saudi Arabia",
+            data: {
+              target_score: 5,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "1",
+            target: "Uruguay",
+            source: "Egypt",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "2",
+            target: "Russia",
+            source: "Egypt",
+            data: {
+              target_score: 3,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "3",
+            target: "Uruguay",
+            source: "Saudi Arabia",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "4",
+            target: "Uruguay",
+            source: "Russia",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "5",
+            target: "Saudi Arabia",
+            source: "Egypt",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "6",
+            target: "IR Iran",
+            source: "Morocco",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "7",
+            target: "Portugal",
+            source: "Spain",
+            data: {
+              target_score: 3,
+              source_score: 3,
+              directed: false,
+            },
+          },
+          {
+            id: "8",
+            target: "Portugal",
+            source: "Morocco",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "9",
+            target: "Spain",
+            source: "IR Iran",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "10",
+            target: "IR Iran",
+            source: "Portugal",
+            data: {
+              target_score: 1,
+              source_score: 1,
+              directed: false,
+            },
+          },
+          {
+            id: "11",
+            target: "Spain",
+            source: "Morocco",
+            data: {
+              target_score: 2,
+              source_score: 2,
+              directed: false,
+            },
+          },
+          {
+            id: "12",
+            target: "France",
+            source: "Australia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "13",
+            target: "Denmark",
+            source: "Peru",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "14",
+            target: "Denmark",
+            source: "Australia",
+            data: {
+              target_score: 1,
+              source_score: 1,
+              directed: false,
+            },
+          },
+          {
+            id: "15",
+            target: "France",
+            source: "Peru",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "16",
+            target: "Denmark",
+            source: "France",
+            data: {
+              target_score: 0,
+              source_score: 0,
+              directed: false,
+            },
+          },
+          {
+            id: "17",
+            target: "Peru",
+            source: "Australia",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "18",
+            target: "Argentina",
+            source: "Iceland",
+            data: {
+              target_score: 1,
+              source_score: 1,
+            },
+          },
+          {
+            id: "19",
+            target: "Croatia",
+            source: "Nigeria",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "20",
+            target: "Croatia",
+            source: "Argentina",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "21",
+            target: "Nigeria",
+            source: "Iceland",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "22",
+            target: "Argentina",
+            source: "Nigeria",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "23",
+            target: "Croatia",
+            source: "Iceland",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "24",
+            target: "Serbia",
+            source: "Costa Rica",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "25",
+            target: "Brazil",
+            source: "Switzerland",
+            data: {
+              target_score: 1,
+              source_score: 1,
+              directed: false,
+            },
+          },
+          {
+            id: "26",
+            target: "Brazil",
+            source: "Costa Rica",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "27",
+            target: "Switzerland",
+            source: "Serbia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "28",
+            target: "Brazil",
+            source: "Serbia",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "29",
+            target: "Switzerland",
+            source: "Costa Rica",
+            data: {
+              target_score: 2,
+              source_score: 2,
+              directed: false,
+            },
+          },
+          {
+            id: "30",
+            target: "Mexico",
+            source: "Germany",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "31",
+            target: "Sweden",
+            source: "Korea Republic",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "32",
+            target: "Mexico",
+            source: "Korea Republic",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "33",
+            target: "Germany",
+            source: "Sweden",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "34",
+            target: "Korea Republic",
+            source: "Germany",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "35",
+            target: "Sweden",
+            source: "Mexico",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "36",
+            target: "Belgium",
+            source: "Panama",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "37",
+            target: "England",
+            source: "Tunisia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "38",
+            target: "Belgium",
+            source: "Tunisia",
+            data: {
+              target_score: 5,
+              source_score: 2,
+              directed: true,
+            },
+          },
+          {
+            id: "39",
+            target: "England",
+            source: "Panama",
+            data: {
+              target_score: 6,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "40",
+            target: "Belgium",
+            source: "England",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "41",
+            target: "Tunisia",
+            source: "Panama",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "42",
+            target: "Japan",
+            source: "Colombia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "43",
+            target: "Senegal",
+            source: "Poland",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "44",
+            target: "Japan",
+            source: "Senegal",
+            data: {
+              target_score: 2,
+              source_score: 2,
+              directed: false,
+            },
+          },
+          {
+            id: "45",
+            target: "Colombia",
+            source: "Poland",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "46",
+            target: "Poland",
+            source: "Japan",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "47",
+            target: "Colombia",
+            source: "Senegal",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "48",
+            target: "Uruguay",
+            source: "Portugal",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "49",
+            target: "France",
+            source: "Argentina",
+            data: {
+              target_score: 4,
+              source_score: 3,
+              directed: true,
+            },
+          },
+          {
+            id: "50",
+            target: "Russia",
+            source: "Spain",
+            data: {
+              target_score: 5,
+              source_score: 4,
+              directed: true,
+            },
+          },
+          {
+            id: "51",
+            target: "Croatia",
+            source: "Denmark",
+            data: {
+              target_score: 4,
+              source_score: 3,
+              directed: true,
+            },
+          },
+          {
+            id: "52",
+            target: "Brazil",
+            source: "Mexico",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "53",
+            target: "Belgium",
+            source: "Japan",
+            data: {
+              target_score: 3,
+              source_score: 2,
+              directed: true,
+            },
+          },
+          {
+            id: "54",
+            target: "Sweden",
+            source: "Switzerland",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "55",
+            target: "England",
+            source: "Colombia",
+            data: {
+              target_score: 4,
+              source_score: 3,
+              directed: true,
+            },
+          },
+          {
+            id: "56",
+            target: "France",
+            source: "Uruguay",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "57",
+            target: "Belgium",
+            source: "Brazil",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "58",
+            target: "Croatia",
+            source: "Russia",
+            data: {
+              target_score: 6,
+              source_score: 5,
+              directed: true,
+            },
+          },
+          {
+            id: "59",
+            target: "England",
+            source: "Sweden",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "60",
+            target: "France",
+            source: "Belgium",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "61",
+            target: "Croatia",
+            source: "England",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "62",
+            target: "Belgium",
+            source: "England",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "63",
+            target: "France",
+            source: "Croatia",
+            data: {
+              target_score: 4,
+              source_score: 2,
+              directed: true,
+            },
+          },
+        ],
+      };
+
+      const graph = new Graph({
+        nodes: data.nodes,
+        edges: data.edges,
+      });
+
+      const fruchterman = new FruchtermanLayout({
+        width: 500,
+        height: 600,
+      });
+
+      let rendered = false;
+      const nodes = [];
+      const edges = [];
+
+      const createNodesEdges = (positions) => {
+        positions.edges.forEach(({ source, target }, i) => {
+          const sourceNode = positions.nodes.find(({ id }) => id === source);
+          const targetNode = positions.nodes.find(({ id }) => id === target);
+          const line = new Line({
+            style: {
+              x1: sourceNode.data.x,
+              y1: sourceNode.data.y,
+              x2: targetNode.data.x,
+              y2: targetNode.data.y,
+              lineWidth: 1,
+              stroke: "grey",
+            },
+          });
+          canvas.appendChild(line);
+          edges.push(line);
+        });
+
+        positions.nodes.forEach((node, i) => {
+          const circle = new Circle({
+            style: {
+              cx: node.data.x,
+              cy: node.data.y,
+              r: 6,
+              fill: "#1890FF",
+              stroke: "#F04864",
+              lineWidth: 2,
+              draggable: true,
+            },
+          });
+          canvas.appendChild(circle);
+
+          let shiftX = 0;
+          let shiftY = 0;
+          function moveAt(target, canvasX, canvasY) {
+            graph.mergeNodeData(positions.nodes[i].id, {
+              x: canvasX - shiftX,
+              y: canvasY - shiftY,
+            });
+            // fruchterman.stop();
+            fruchterman.assign(graph, {
+              onLayoutEnd: (positions) => {
+                updateNodesEdges(positions);
+              },
+            });
+          }
+
+          circle.addEventListener("dragstart", function (e) {
+            const [x, y] = e.target.getPosition();
+            shiftX = e.canvasX - x;
+            shiftY = e.canvasY - y;
+
+            moveAt(e.target, e.canvasX, e.canvasY);
+          });
+          circle.addEventListener("drag", function (e) {
+            moveAt(e.target, e.canvasX, e.canvasY);
+          });
+          nodes.push(circle);
+        });
+      };
+
+      const updateNodesEdges = (positions) => {
+        positions.edges.forEach(({ source, target }, i) => {
+          const sourceNode = positions.nodes.find(({ id }) => id === source);
+          const targetNode = positions.nodes.find(({ id }) => id === target);
+
+          edges[i].attr({
+            x1: sourceNode.data.x,
+            y1: sourceNode.data.y,
+            x2: targetNode.data.x,
+            y2: targetNode.data.y,
+          });
+        });
+
+        positions.nodes.forEach((node, i) => {
+          nodes[i].attr({
+            cx: node.data.x,
+            cy: node.data.y,
+          });
+        });
+      };
+
+      fruchterman.assign(graph, {
+        onLayoutEnd: (positions) => {
+          createNodesEdges(positions);
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/demo/gforce.gpu.html
+++ b/demo/gforce.gpu.html
@@ -1,0 +1,1014 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,shrink-to-fit=no"
+    />
+    <title>GForce GPU</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html,
+      body {
+        height: 100%;
+      }
+
+      #container {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="container"></div>
+    <script
+      src="https://unpkg.com/@antv/g"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@antv/g-canvas"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@antv/g-plugin-dragndrop"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../packages/layout/dist/index.min.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="../packages/layout-gpu/dist/index.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      const { Graph } = window.GraphLib;
+      const { GForceLayout } = window.LayoutGPU;
+
+      const { Circle, Line, Canvas } = window.G;
+      // create a renderer
+      const canvasRenderer = new window.G.Canvas2D.Renderer();
+      const plugin = new window.G.Dragndrop.Plugin();
+      canvasRenderer.registerPlugin(plugin);
+      // create a canvas
+      const canvas = new Canvas({
+        container: "container",
+        width: 500,
+        height: 500,
+        renderer: canvasRenderer,
+      });
+
+      const data = {
+        nodes: [
+          {
+            id: "Argentina",
+            data: {
+              name: "Argentina",
+            },
+          },
+          {
+            id: "Australia",
+            data: {
+              name: "Australia",
+            },
+          },
+          {
+            id: "Belgium",
+            data: {
+              name: "Belgium",
+            },
+          },
+          {
+            id: "Brazil",
+            data: {
+              name: "Brazil",
+            },
+          },
+          {
+            id: "Colombia",
+            data: {
+              name: "Colombia",
+            },
+          },
+          {
+            id: "Costa Rica",
+            data: {
+              name: "Costa Rica",
+            },
+          },
+          {
+            id: "Croatia",
+            data: {
+              name: "Croatia",
+            },
+          },
+          {
+            id: "Denmark",
+            data: {
+              name: "Denmark",
+            },
+          },
+          {
+            id: "Egypt",
+            data: {
+              name: "Egypt",
+            },
+          },
+          {
+            id: "England",
+            data: {
+              name: "England",
+            },
+          },
+          {
+            id: "France",
+            data: {
+              name: "France",
+            },
+          },
+          {
+            id: "Germany",
+            data: {
+              name: "Germany",
+            },
+          },
+          {
+            id: "Iceland",
+            data: {
+              name: "Iceland",
+            },
+          },
+          {
+            id: "IR Iran",
+            data: {
+              name: "IR Iran",
+            },
+          },
+          {
+            id: "Japan",
+            data: {
+              name: "Japan",
+            },
+          },
+          {
+            id: "Korea Republic",
+            data: {
+              name: "Korea Republic",
+            },
+          },
+          {
+            id: "Mexico",
+            data: {
+              name: "Mexico",
+            },
+          },
+          {
+            id: "Morocco",
+            data: {
+              name: "Morocco",
+            },
+          },
+          {
+            id: "Nigeria",
+            data: {
+              name: "Nigeria",
+            },
+          },
+          {
+            id: "Panama",
+            data: {
+              name: "Panama",
+            },
+          },
+          {
+            id: "Peru",
+            data: {
+              name: "Peru",
+            },
+          },
+          {
+            id: "Poland",
+            data: {
+              name: "Poland",
+            },
+          },
+          {
+            id: "Portugal",
+            data: {
+              name: "Portugal",
+            },
+          },
+          {
+            id: "Russia",
+            data: {
+              name: "Russia",
+            },
+          },
+          {
+            id: "Saudi Arabia",
+            data: {
+              name: "Saudi Arabia",
+            },
+          },
+          {
+            id: "Senegal",
+            data: {
+              name: "Senegal",
+            },
+          },
+          {
+            id: "Serbia",
+            data: {
+              name: "Serbia",
+            },
+          },
+          {
+            id: "Spain",
+            data: {
+              name: "Spain",
+            },
+          },
+          {
+            id: "Sweden",
+            data: {
+              name: "Sweden",
+            },
+          },
+          {
+            id: "Switzerland",
+            data: {
+              name: "Switzerland",
+            },
+          },
+          {
+            id: "Tunisia",
+            data: {
+              name: "Tunisia",
+            },
+          },
+          {
+            id: "Uruguay",
+            data: {
+              name: "Uruguay",
+            },
+          },
+        ],
+        edges: [
+          {
+            id: "0",
+            target: "Russia",
+            source: "Saudi Arabia",
+            data: {
+              target_score: 5,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "1",
+            target: "Uruguay",
+            source: "Egypt",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "2",
+            target: "Russia",
+            source: "Egypt",
+            data: {
+              target_score: 3,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "3",
+            target: "Uruguay",
+            source: "Saudi Arabia",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "4",
+            target: "Uruguay",
+            source: "Russia",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "5",
+            target: "Saudi Arabia",
+            source: "Egypt",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "6",
+            target: "IR Iran",
+            source: "Morocco",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "7",
+            target: "Portugal",
+            source: "Spain",
+            data: {
+              target_score: 3,
+              source_score: 3,
+              directed: false,
+            },
+          },
+          {
+            id: "8",
+            target: "Portugal",
+            source: "Morocco",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "9",
+            target: "Spain",
+            source: "IR Iran",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "10",
+            target: "IR Iran",
+            source: "Portugal",
+            data: {
+              target_score: 1,
+              source_score: 1,
+              directed: false,
+            },
+          },
+          {
+            id: "11",
+            target: "Spain",
+            source: "Morocco",
+            data: {
+              target_score: 2,
+              source_score: 2,
+              directed: false,
+            },
+          },
+          {
+            id: "12",
+            target: "France",
+            source: "Australia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "13",
+            target: "Denmark",
+            source: "Peru",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "14",
+            target: "Denmark",
+            source: "Australia",
+            data: {
+              target_score: 1,
+              source_score: 1,
+              directed: false,
+            },
+          },
+          {
+            id: "15",
+            target: "France",
+            source: "Peru",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "16",
+            target: "Denmark",
+            source: "France",
+            data: {
+              target_score: 0,
+              source_score: 0,
+              directed: false,
+            },
+          },
+          {
+            id: "17",
+            target: "Peru",
+            source: "Australia",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "18",
+            target: "Argentina",
+            source: "Iceland",
+            data: {
+              target_score: 1,
+              source_score: 1,
+            },
+          },
+          {
+            id: "19",
+            target: "Croatia",
+            source: "Nigeria",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "20",
+            target: "Croatia",
+            source: "Argentina",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "21",
+            target: "Nigeria",
+            source: "Iceland",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "22",
+            target: "Argentina",
+            source: "Nigeria",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "23",
+            target: "Croatia",
+            source: "Iceland",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "24",
+            target: "Serbia",
+            source: "Costa Rica",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "25",
+            target: "Brazil",
+            source: "Switzerland",
+            data: {
+              target_score: 1,
+              source_score: 1,
+              directed: false,
+            },
+          },
+          {
+            id: "26",
+            target: "Brazil",
+            source: "Costa Rica",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "27",
+            target: "Switzerland",
+            source: "Serbia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "28",
+            target: "Brazil",
+            source: "Serbia",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "29",
+            target: "Switzerland",
+            source: "Costa Rica",
+            data: {
+              target_score: 2,
+              source_score: 2,
+              directed: false,
+            },
+          },
+          {
+            id: "30",
+            target: "Mexico",
+            source: "Germany",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "31",
+            target: "Sweden",
+            source: "Korea Republic",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "32",
+            target: "Mexico",
+            source: "Korea Republic",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "33",
+            target: "Germany",
+            source: "Sweden",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "34",
+            target: "Korea Republic",
+            source: "Germany",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "35",
+            target: "Sweden",
+            source: "Mexico",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "36",
+            target: "Belgium",
+            source: "Panama",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "37",
+            target: "England",
+            source: "Tunisia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "38",
+            target: "Belgium",
+            source: "Tunisia",
+            data: {
+              target_score: 5,
+              source_score: 2,
+              directed: true,
+            },
+          },
+          {
+            id: "39",
+            target: "England",
+            source: "Panama",
+            data: {
+              target_score: 6,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "40",
+            target: "Belgium",
+            source: "England",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "41",
+            target: "Tunisia",
+            source: "Panama",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "42",
+            target: "Japan",
+            source: "Colombia",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "43",
+            target: "Senegal",
+            source: "Poland",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "44",
+            target: "Japan",
+            source: "Senegal",
+            data: {
+              target_score: 2,
+              source_score: 2,
+              directed: false,
+            },
+          },
+          {
+            id: "45",
+            target: "Colombia",
+            source: "Poland",
+            data: {
+              target_score: 3,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "46",
+            target: "Poland",
+            source: "Japan",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "47",
+            target: "Colombia",
+            source: "Senegal",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "48",
+            target: "Uruguay",
+            source: "Portugal",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "49",
+            target: "France",
+            source: "Argentina",
+            data: {
+              target_score: 4,
+              source_score: 3,
+              directed: true,
+            },
+          },
+          {
+            id: "50",
+            target: "Russia",
+            source: "Spain",
+            data: {
+              target_score: 5,
+              source_score: 4,
+              directed: true,
+            },
+          },
+          {
+            id: "51",
+            target: "Croatia",
+            source: "Denmark",
+            data: {
+              target_score: 4,
+              source_score: 3,
+              directed: true,
+            },
+          },
+          {
+            id: "52",
+            target: "Brazil",
+            source: "Mexico",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "53",
+            target: "Belgium",
+            source: "Japan",
+            data: {
+              target_score: 3,
+              source_score: 2,
+              directed: true,
+            },
+          },
+          {
+            id: "54",
+            target: "Sweden",
+            source: "Switzerland",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "55",
+            target: "England",
+            source: "Colombia",
+            data: {
+              target_score: 4,
+              source_score: 3,
+              directed: true,
+            },
+          },
+          {
+            id: "56",
+            target: "France",
+            source: "Uruguay",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "57",
+            target: "Belgium",
+            source: "Brazil",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "58",
+            target: "Croatia",
+            source: "Russia",
+            data: {
+              target_score: 6,
+              source_score: 5,
+              directed: true,
+            },
+          },
+          {
+            id: "59",
+            target: "England",
+            source: "Sweden",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "60",
+            target: "France",
+            source: "Belgium",
+            data: {
+              target_score: 1,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "61",
+            target: "Croatia",
+            source: "England",
+            data: {
+              target_score: 2,
+              source_score: 1,
+              directed: true,
+            },
+          },
+          {
+            id: "62",
+            target: "Belgium",
+            source: "England",
+            data: {
+              target_score: 2,
+              source_score: 0,
+              directed: true,
+            },
+          },
+          {
+            id: "63",
+            target: "France",
+            source: "Croatia",
+            data: {
+              target_score: 4,
+              source_score: 2,
+              directed: true,
+            },
+          },
+        ],
+      };
+
+      const graph = new Graph({
+        nodes: data.nodes,
+        edges: data.edges,
+      });
+
+      const fruchterman = new GForceLayout({
+        width: 500,
+        height: 600,
+      });
+
+      let rendered = false;
+      const nodes = [];
+      const edges = [];
+
+      const createNodesEdges = (positions) => {
+        positions.edges.forEach(({ source, target }, i) => {
+          const sourceNode = positions.nodes.find(({ id }) => id === source);
+          const targetNode = positions.nodes.find(({ id }) => id === target);
+          const line = new Line({
+            style: {
+              x1: sourceNode.data.x,
+              y1: sourceNode.data.y,
+              x2: targetNode.data.x,
+              y2: targetNode.data.y,
+              lineWidth: 1,
+              stroke: "grey",
+            },
+          });
+          canvas.appendChild(line);
+          edges.push(line);
+        });
+
+        positions.nodes.forEach((node, i) => {
+          const circle = new Circle({
+            style: {
+              cx: node.data.x,
+              cy: node.data.y,
+              r: 6,
+              fill: "#1890FF",
+              stroke: "#F04864",
+              lineWidth: 2,
+              draggable: true,
+            },
+          });
+          canvas.appendChild(circle);
+
+          let shiftX = 0;
+          let shiftY = 0;
+          function moveAt(target, canvasX, canvasY) {
+            graph.mergeNodeData(positions.nodes[i].id, {
+              x: canvasX - shiftX,
+              y: canvasY - shiftY,
+            });
+            // fruchterman.stop();
+            fruchterman.assign(graph, {
+              onLayoutEnd: (positions) => {
+                updateNodesEdges(positions);
+              },
+            });
+          }
+
+          circle.addEventListener("dragstart", function (e) {
+            const [x, y] = e.target.getPosition();
+            shiftX = e.canvasX - x;
+            shiftY = e.canvasY - y;
+
+            moveAt(e.target, e.canvasX, e.canvasY);
+          });
+          circle.addEventListener("drag", function (e) {
+            moveAt(e.target, e.canvasX, e.canvasY);
+          });
+          nodes.push(circle);
+        });
+      };
+
+      const updateNodesEdges = (positions) => {
+        positions.edges.forEach(({ source, target }, i) => {
+          const sourceNode = positions.nodes.find(({ id }) => id === source);
+          const targetNode = positions.nodes.find(({ id }) => id === target);
+
+          edges[i].attr({
+            x1: sourceNode.data.x,
+            y1: sourceNode.data.y,
+            x2: targetNode.data.x,
+            y2: targetNode.data.y,
+          });
+        });
+
+        positions.nodes.forEach((node, i) => {
+          nodes[i].attr({
+            cx: node.data.x,
+            cy: node.data.y,
+          });
+        });
+      };
+
+      fruchterman.assign(graph, {
+        onLayoutEnd: (positions) => {
+          console.log(positions);
+          createNodesEdges(positions);
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/packages/layout-gpu/.babelrc.js
+++ b/packages/layout-gpu/.babelrc.js
@@ -1,0 +1,18 @@
+module.exports = (api) => {
+  api.cache(() => process.env.NODE_ENV);
+  return {
+    presets: [
+      [
+        "@babel/preset-env",
+        {
+          loose: true,
+          modules: false,
+        },
+      ],
+      "@babel/preset-react",
+      {
+        plugins: ["@babel/plugin-proposal-class-properties"],
+      },
+    ],
+  };
+};

--- a/packages/layout-gpu/LICENSE
+++ b/packages/layout-gpu/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Alipay.inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/layout-gpu/README.md
+++ b/packages/layout-gpu/README.md
@@ -1,8 +1,10 @@
-## About
+# @antv/layout-gpu
 
-Collection of basic layout algorithms to be used with [@antv/graphlib]().
+Accelerate some parallelizable algorithms such as Fruchterman with WebGPU which has a better performance under large amount of data.
 
-## Installation
+## Usage
+
+### NPM
 
 ```shell
 # npm
@@ -11,6 +13,94 @@ $ npm install @antv/layout-gpu --save
 # yarn
 $ yarn add @antv/layout-gpu
 ```
+
+Choose a layout algorithm from `@antv/layout-gpu` then. Since the GPGPU is asynchronous, `onLayoutEnd` callback should be passed in.
+
+```ts
+import { Graph } from "@antv/graphlib";
+import { FruchtermanLayout } from "@antv/layout-gpu";
+
+const graph = new Graph({ nodes: [], edges: [] });
+
+const fruchtermanLayout = new FruchtermanLayout({
+  onLayoutEnd: (positions) => {
+    // render nodes & edges
+  },
+});
+
+// Return positions of nodes & edges.
+const positions = fruchtermanLayout.execute(graph);
+// Or to directly assign the positions to the nodes:
+circularLayout.assign(graph);
+```
+
+### UMD
+
+Import scripts in UMD version of `@antv/graphlib`, `@antv/layout` and `@antv/layout-gpu`.
+
+```html
+<script
+  src="https://unpkg.com/@antv/graphlib"
+  type="application/javascript"
+></script>
+<script
+  src="https://unpkg.com/@antv/layout"
+  type="application/javascript"
+></script>
+<script
+  src="https://unpkg.com/@antv/layout-gpu"
+  type="application/javascript"
+></script>
+```
+
+Use layouts under `LayoutGPU` namespace.
+
+```js
+const { Graph } = window.GraphLib;
+const { FruchtermanLayout } = window.LayoutGPU;
+```
+
+## Documentation
+
+We provide the following parallelizable layouts:
+
+- [Fruchterman]()
+- [GForce]()
+
+Since the GPGPU is asynchronous, `onLayoutEnd` callback should be passed in.
+
+```js
+import { Graph } from "@antv/graphlib";
+import { FruchtermanLayout } from "@antv/layout-gpu";
+
+const graph = new Graph({ nodes: [], edges: [] });
+
+const fruchtermanLayout = new FruchtermanLayout({
+  onLayoutEnd: (positions) => {
+    // render nodes & edges
+  },
+});
+fruchtermanLayout.assign(graph);
+```
+
+### Fruchterman
+
+Fruchterman is a kind of force-directed layout. The implementation is according to the paper [Graph Drawing by Force-directed Placement](http://www.mathe2.uni-bayreuth.de/axel/papers/reingold:graph_drawing_by_force_directed_placement.pdf).
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*jK3ITYqVJnQAAAAAAAAAAABkARQnAQ" alt="fruchterman layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-1058)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `width` **number** The width of the graph. The default value is `300`.
+- `height` **number** The height of the graph. The default value is `300`.
+- `maxIteration` **number** The default value is `1000`.
+- `gravity` **number** The gravity, which will affect the compactness of the layout. The default value is `10`.
+- `speed` **number** The moving speed of each iteraction. Large value of the speed might lead to violent swing. The default value is `5`.
+
+### GForce
 
 ## License
 

--- a/packages/layout-gpu/package.json
+++ b/packages/layout-gpu/package.json
@@ -9,6 +9,7 @@
   "files": [
     "package.json",
     "dist",
+    "esm",
     "lib",
     "LICENSE",
     "README.md"
@@ -20,12 +21,13 @@
     "antv"
   ],
   "dependencies": {
-    "@antv/graphlib": "^2.0.0-alpha.1",
-    "@antv/g": "^5.15.8",
-    "@antv/g-webgpu": "^1.7.38",
-    "@antv/g-plugin-gpgpu": "^1.7.35"
+    "@antv/g-webgpu": "0.7.2",
+    "@antv/layout": "^1.0.0-alpha.13",
+    "@antv/util": "^3.0.0",
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
+    "@antv/g-webgpu-compiler": "0.7.2",
     "@babel/core": "^7.7.7",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-react": "^7.7.4",
@@ -37,8 +39,9 @@
   },
   "scripts": {
     "dev": "webpack --config webpack.dev.config.js --mode development",
+    "build": "npm run build:esm && npm run build:umd",
+    "build:esm": "webpack --config webpack.esm.config.js --mode production",
     "build:umd": "webpack --config webpack.config.js --mode production",
-    "publish:alpha": "npm publish --tag alpha",
-    "test": "jest"
+    "publish:alpha": "npm publish --tag alpha"
   }
 }

--- a/packages/layout-gpu/package.json
+++ b/packages/layout-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout-gpu",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "graph layout algorithm implemented with GPGPU",
   "main": "dist/index.min.js",
   "module": "esm/index.esm.js",

--- a/packages/layout-gpu/package.json
+++ b/packages/layout-gpu/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@antv/layout-gpu",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "graph layout algorithm implemented with GPGPU",
   "main": "dist/index.min.js",
-  "module": "dist/index.min.js",
+  "module": "esm/index.esm.js",
   "types": "lib/index.d.ts",
   "unpkg": "dist/index.min.js",
   "files": [

--- a/packages/layout-gpu/src/fruchterman-shader.ts
+++ b/packages/layout-gpu/src/fruchterman-shader.ts
@@ -1,0 +1,203 @@
+export const fruchtermanCode = `
+import { globalInvocationID } from 'g-webgpu';
+const MAX_EDGE_PER_VERTEX;
+const VERTEX_COUNT;
+@numthreads(1, 1, 1)
+class Fruchterman {
+  @in @out
+  u_Data: vec4[];
+  @in
+  u_K: float;
+  @in
+  u_K2: float;
+  
+  @in
+  u_Center: vec2;
+  @in
+  u_Gravity: float;
+  @in
+  u_ClusterGravity: float;
+  @in
+  u_Speed: float;
+  @in
+  u_MaxDisplace: float;
+  @in
+  u_Clustering: float;
+  @in
+  u_AttributeArray: vec4[];
+  @in
+  u_ClusterCenters: vec4[];
+  calcRepulsive(i: int, currentNode: vec4): vec2 {
+    let dx = 0, dy = 0;
+    for (let j = 0; j < VERTEX_COUNT; j++) {
+      if (i != j) {
+        const nextNode = this.u_Data[j];
+        const xDist = currentNode[0] - nextNode[0];
+        const yDist = currentNode[1] - nextNode[1];
+        const dist = (xDist * xDist + yDist * yDist) + 0.01;
+        let param = this.u_K2 / dist;
+        
+        if (dist > 0.0) {
+          dx += param * xDist;
+          dy += param * yDist;
+          if (xDist == 0 && yDist == 0) {
+            const sign = i < j ? 1 : -1;
+            dx += param * sign;
+            dy += param * sign;
+          }
+        }
+      }
+    }
+    return [dx, dy];
+  }
+  calcGravity(currentNode: vec4, nodeAttributes: vec4): vec2 { // 
+    let dx = 0, dy = 0;
+    const vx = currentNode[0] - this.u_Center[0];
+    const vy = currentNode[1] - this.u_Center[1];
+    const gf = 0.01 * this.u_K * this.u_Gravity;
+    dx = gf * vx;
+    dy = gf * vy;
+    if (this.u_Clustering == 1) {
+      const clusterIdx = int(nodeAttributes[0]);
+      const center = this.u_ClusterCenters[clusterIdx];
+      const cvx = currentNode[0] - center[0];
+      const cvy = currentNode[1] - center[1];
+      const dist = sqrt(cvx * cvx + cvy * cvy) + 0.01;
+      const parma = this.u_K * this.u_ClusterGravity / dist;
+      dx += parma * cvx;
+      dy += parma * cvy;
+    }
+    return [dx, dy];
+  }
+  calcAttractive(i: int, currentNode: vec4): vec2 {
+    let dx = 0, dy = 0;
+    const arr_offset = int(floor(currentNode[2] + 0.5));
+    const length = int(floor(currentNode[3] + 0.5));
+    const node_buffer: vec4;
+    for (let p = 0; p < MAX_EDGE_PER_VERTEX; p++) {
+      if (p >= length) break;
+      const arr_idx = arr_offset + p;
+      // when arr_idx % 4 == 0 update currentNodedx_buffer
+      const buf_offset = arr_idx - arr_idx / 4 * 4;
+      if (p == 0 || buf_offset == 0) {
+        node_buffer = this.u_Data[int(arr_idx / 4)];
+      }
+      const float_j = buf_offset == 0 ? node_buffer[0] :
+                      buf_offset == 1 ? node_buffer[1] :
+                      buf_offset == 2 ? node_buffer[2] :
+                                        node_buffer[3];
+      const nextNode = this.u_Data[int(float_j)];
+      const xDist = currentNode[0] - nextNode[0];
+      const yDist = currentNode[1] - nextNode[1];
+      const dist = sqrt(xDist * xDist + yDist * yDist) + 0.01;
+      let attractiveF = dist / this.u_K;
+    
+      if (dist > 0.0) {
+        dx -= xDist * attractiveF;
+        dy -= yDist * attractiveF;
+        if (xDist == 0 && yDist == 0) {
+          const sign = i < int(float_j) ? 1 : -1;
+          dx -= sign * attractiveF;
+          dy -= sign * attractiveF;
+        }
+      }
+    }
+    return [dx, dy];
+  }
+  @main
+  compute() {
+    const i = globalInvocationID.x;
+    const currentNode = this.u_Data[i];
+    let dx = 0, dy = 0;
+    if (i >= VERTEX_COUNT) {
+      this.u_Data[i] = currentNode;
+      return;
+    }
+
+    // [gravity, fx, fy, 0]
+    const nodeAttributes = this.u_AttributeArray[i];
+
+    if (nodeAttributes[1] != 0 && nodeAttributes[2] != 0) {
+      // the node is fixed
+      this.u_Data[i] = [
+        nodeAttributes[1],
+        nodeAttributes[2],
+        currentNode[2],
+        currentNode[3]
+      ];
+      return;
+    }
+
+    // repulsive
+    const repulsive = this.calcRepulsive(i, currentNode);
+    dx += repulsive[0];
+    dy += repulsive[1];
+    // attractive
+    const attractive = this.calcAttractive(i, currentNode);
+    dx += attractive[0];
+    dy += attractive[1];
+    // gravity
+    const gravity = this.calcGravity(currentNode, nodeAttributes);
+    dx -= gravity[0];
+    dy -= gravity[1];
+    // speed
+    dx *= this.u_Speed;
+    dy *= this.u_Speed;
+
+    // move
+    const distLength = sqrt(dx * dx + dy * dy);
+    if (distLength > 0.0) {
+      const limitedDist = min(this.u_MaxDisplace * this.u_Speed, distLength);
+      this.u_Data[i] = [
+        currentNode[0] + dx / distLength * limitedDist,
+        currentNode[1] + dy / distLength * limitedDist,
+        currentNode[2],
+        currentNode[3]
+      ];
+    }
+  }
+}
+`;
+
+export const fruchtermanBundle = `{"shaders":{"WGSL":"","GLSL450":"","GLSL100":"\\n\\nfloat epsilon = 0.00001;\\nvec2 addrTranslation_1Dto2D(float address1D, vec2 texSize) {\\n  vec2 conv_const = vec2(1.0 / texSize.x, 1.0 / (texSize.x * texSize.y));\\n  vec2 normAddr2D = float(address1D) * conv_const;\\n  return vec2(fract(normAddr2D.x + epsilon), normAddr2D.y);\\n}\\n\\nvoid barrier() {}\\n  \\n\\nuniform vec2 u_OutputTextureSize;\\nuniform int u_OutputTexelCount;\\nvarying vec2 v_TexCoord;\\n\\nbool gWebGPUDebug = false;\\nvec4 gWebGPUDebugOutput = vec4(0.0);\\n\\n#define MAX_EDGE_PER_VERTEX __DefineValuePlaceholder__MAX_EDGE_PER_VERTEX\\n#define VERTEX_COUNT __DefineValuePlaceholder__VERTEX_COUNT\\n\\nuniform sampler2D u_Data;\\nuniform vec2 u_DataSize;\\nvec4 getDatau_Data(vec2 address2D) {\\n  return vec4(texture2D(u_Data, address2D).rgba);\\n}\\nvec4 getDatau_Data(float address1D) {\\n  return getDatau_Data(addrTranslation_1Dto2D(address1D, u_DataSize));\\n}\\nvec4 getDatau_Data(int address1D) {\\n  return getDatau_Data(float(address1D));\\n}\\nuniform float u_K;\\nuniform float u_K2;\\nuniform vec2 u_Center;\\nuniform float u_Gravity;\\nuniform float u_ClusterGravity;\\nuniform float u_Speed;\\nuniform float u_MaxDisplace;\\nuniform float u_Clustering;\\nuniform sampler2D u_AttributeArray;\\nuniform vec2 u_AttributeArraySize;\\nvec4 getDatau_AttributeArray(vec2 address2D) {\\n  return vec4(texture2D(u_AttributeArray, address2D).rgba);\\n}\\nvec4 getDatau_AttributeArray(float address1D) {\\n  return getDatau_AttributeArray(addrTranslation_1Dto2D(address1D, u_AttributeArraySize));\\n}\\nvec4 getDatau_AttributeArray(int address1D) {\\n  return getDatau_AttributeArray(float(address1D));\\n}\\nuniform sampler2D u_ClusterCenters;\\nuniform vec2 u_ClusterCentersSize;\\nvec4 getDatau_ClusterCenters(vec2 address2D) {\\n  return vec4(texture2D(u_ClusterCenters, address2D).rgba);\\n}\\nvec4 getDatau_ClusterCenters(float address1D) {\\n  return getDatau_ClusterCenters(addrTranslation_1Dto2D(address1D, u_ClusterCentersSize));\\n}\\nvec4 getDatau_ClusterCenters(int address1D) {\\n  return getDatau_ClusterCenters(float(address1D));\\n}\\nvec2 calcRepulsive(int i, vec4 currentNode) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat dx = 0.0;\\nfloat dy = 0.0;\\nfor (int j = 0; j < VERTEX_COUNT; j++) {if (i != j) {vec4 nextNode = getDatau_Data(j);\\nfloat xDist = currentNode.x - nextNode.x;\\nfloat yDist = currentNode.y - nextNode.y;\\nfloat dist = ((xDist * xDist) + (yDist * yDist)) + 0.01;\\nfloat param = u_K2 / dist;\\nif (dist > 0.0) {dx += param * xDist;\\ndy += param * yDist;\\nif ((xDist == 0.0) && (yDist == 0.0)) {float sign = (i < j) ? (1.0) : (-1.0);\\ndx += param * sign;\\ndy += param * sign;}}}}\\nreturn vec2(dx, dy);}\\nvec2 calcGravity(vec4 currentNode, vec4 nodeAttributes) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat dx = 0.0;\\nfloat dy = 0.0;\\nfloat vx = currentNode.x - u_Center.x;\\nfloat vy = currentNode.y - u_Center.y;\\nfloat gf = (0.01 * u_K) * u_Gravity;\\ndx = gf * vx;\\ndy = gf * vy;\\nif (u_Clustering == 1.0) {int clusterIdx = int(nodeAttributes.x);\\nvec4 center = getDatau_ClusterCenters(clusterIdx);\\nfloat cvx = currentNode.x - center.x;\\nfloat cvy = currentNode.y - center.y;\\nfloat dist = sqrt((cvx * cvx) + (cvy * cvy)) + 0.01;\\nfloat parma = (u_K * u_ClusterGravity) / dist;\\ndx += parma * cvx;\\ndy += parma * cvy;}\\nreturn vec2(dx, dy);}\\nvec2 calcAttractive(int i, vec4 currentNode) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat dx = 0.0;\\nfloat dy = 0.0;\\nint arr_offset = int(floor(currentNode.z + 0.5));\\nint length = int(floor(currentNode.w + 0.5));\\nvec4 node_buffer;\\nfor (int p = 0; p < MAX_EDGE_PER_VERTEX; p++) {if (p >= length) {break;}\\nint arr_idx = arr_offset + int(p);\\nint buf_offset = arr_idx - ((arr_idx / 4) * 4);\\nif ((p == 0) || (buf_offset == 0)) {node_buffer = getDatau_Data(int(arr_idx / 4));}\\nfloat float_j = (buf_offset == 0) ? (node_buffer.x) : ((buf_offset == 1) ? (node_buffer.y) : ((buf_offset == 2) ? (node_buffer.z) : (node_buffer.w)));\\nvec4 nextNode = getDatau_Data(int(float_j));\\nfloat xDist = currentNode.x - nextNode.x;\\nfloat yDist = currentNode.y - nextNode.y;\\nfloat dist = sqrt((xDist * xDist) + (yDist * yDist)) + 0.01;\\nfloat attractiveF = dist / u_K;\\nif (dist > 0.0) {dx -= xDist * attractiveF;\\ndy -= yDist * attractiveF;\\nif ((xDist == 0.0) && (yDist == 0.0)) {float sign = (i < int(float_j)) ? (1.0) : (-1.0);\\ndx -= sign * attractiveF;\\ndy -= sign * attractiveF;}}}\\nreturn vec2(dx, dy);}\\nvoid main() {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nint i = globalInvocationID.x;\\nvec4 currentNode = getDatau_Data(i);\\nfloat dx = 0.0;\\nfloat dy = 0.0;\\nif (i >= VERTEX_COUNT) {gl_FragColor = vec4(currentNode);\\nreturn ;}\\nvec4 nodeAttributes = getDatau_AttributeArray(i);\\nif ((nodeAttributes.y != 0.0) && (nodeAttributes.z != 0.0)) {gl_FragColor = vec4(vec4(nodeAttributes.y, nodeAttributes.z, currentNode.z, currentNode.w));\\nreturn ;}\\nvec2 repulsive = calcRepulsive(i, currentNode);\\ndx += repulsive.x;\\ndy += repulsive.y;\\nvec2 attractive = calcAttractive(i, currentNode);\\ndx += attractive.x;\\ndy += attractive.y;\\nvec2 gravity = calcGravity(currentNode, nodeAttributes);\\ndx -= gravity.x;\\ndy -= gravity.y;\\ndx *= u_Speed;\\ndy *= u_Speed;\\nfloat distLength = sqrt((dx * dx) + (dy * dy));\\nif (distLength > 0.0) {float limitedDist = min(u_MaxDisplace * u_Speed, distLength);\\ngl_FragColor = vec4(vec4(currentNode.x + ((dx / distLength) * limitedDist), currentNode.y + ((dy / distLength) * limitedDist), currentNode.z, currentNode.w));}if (gWebGPUDebug) {\\n  gl_FragColor = gWebGPUDebugOutput;\\n}}\\n"},"context":{"name":"","dispatch":[1,1,1],"threadGroupSize":[1,1,1],"maxIteration":1,"defines":[{"name":"MAX_EDGE_PER_VERTEX","type":"Float","runtime":true},{"name":"VERTEX_COUNT","type":"Float","runtime":true}],"uniforms":[{"name":"u_Data","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":false,"writeonly":false,"size":[1,1]},{"name":"u_K","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_K2","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_Center","type":"vec2<f32>","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_Gravity","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_ClusterGravity","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_Speed","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_MaxDisplace","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_Clustering","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_AttributeArray","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_ClusterCenters","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]}],"globalDeclarations":[],"output":{"name":"u_Data","size":[1,1],"length":1},"needPingpong":true}}`;
+
+export const clusterCode = `
+import { globalInvocationID } from 'g-webgpu';
+const VERTEX_COUNT;
+const CLUSTER_COUNT;
+@numthreads(1, 1, 1)
+class CalcCenter {
+  @in
+  u_Data: vec4[];
+  @in
+  u_NodeAttributes: vec4[]; // [[clusterIdx, 0, 0, 0], ...]
+  @in @out
+  u_ClusterCenters: vec4[]; // [[cx, cy, nodeCount, clusterIdx], ...]
+  @main
+  compute() {
+    const i = globalInvocationID.x;
+    const center = this.u_ClusterCenters[i];
+    let sumx = 0;
+    let sumy = 0;
+    let count = 0;
+    for (let j = 0; j < VERTEX_COUNT; j++) {
+      const attributes = this.u_NodeAttributes[j];
+      const clusterIdx = int(attributes[0]);
+      const vertex = this.u_Data[j];
+      if (clusterIdx == i) {
+        sumx += vertex.x;
+        sumy += vertex.y;
+        count += 1;
+      }
+    }
+    this.u_ClusterCenters[i] = [
+      sumx / count,
+      sumy / count,
+      count,
+      i
+    ];
+  }
+}
+`;
+
+export const clusterBundle = `{"shaders":{"WGSL":"","GLSL450":"","GLSL100":"\\n\\nfloat epsilon = 0.00001;\\nvec2 addrTranslation_1Dto2D(float address1D, vec2 texSize) {\\n  vec2 conv_const = vec2(1.0 / texSize.x, 1.0 / (texSize.x * texSize.y));\\n  vec2 normAddr2D = float(address1D) * conv_const;\\n  return vec2(fract(normAddr2D.x + epsilon), normAddr2D.y);\\n}\\n\\nvoid barrier() {}\\n  \\n\\nuniform vec2 u_OutputTextureSize;\\nuniform int u_OutputTexelCount;\\nvarying vec2 v_TexCoord;\\n\\nbool gWebGPUDebug = false;\\nvec4 gWebGPUDebugOutput = vec4(0.0);\\n\\n#define VERTEX_COUNT __DefineValuePlaceholder__VERTEX_COUNT\\n#define CLUSTER_COUNT __DefineValuePlaceholder__CLUSTER_COUNT\\n\\nuniform sampler2D u_Data;\\nuniform vec2 u_DataSize;\\nvec4 getDatau_Data(vec2 address2D) {\\n  return vec4(texture2D(u_Data, address2D).rgba);\\n}\\nvec4 getDatau_Data(float address1D) {\\n  return getDatau_Data(addrTranslation_1Dto2D(address1D, u_DataSize));\\n}\\nvec4 getDatau_Data(int address1D) {\\n  return getDatau_Data(float(address1D));\\n}\\nuniform sampler2D u_NodeAttributes;\\nuniform vec2 u_NodeAttributesSize;\\nvec4 getDatau_NodeAttributes(vec2 address2D) {\\n  return vec4(texture2D(u_NodeAttributes, address2D).rgba);\\n}\\nvec4 getDatau_NodeAttributes(float address1D) {\\n  return getDatau_NodeAttributes(addrTranslation_1Dto2D(address1D, u_NodeAttributesSize));\\n}\\nvec4 getDatau_NodeAttributes(int address1D) {\\n  return getDatau_NodeAttributes(float(address1D));\\n}\\nuniform sampler2D u_ClusterCenters;\\nuniform vec2 u_ClusterCentersSize;\\nvec4 getDatau_ClusterCenters(vec2 address2D) {\\n  return vec4(texture2D(u_ClusterCenters, address2D).rgba);\\n}\\nvec4 getDatau_ClusterCenters(float address1D) {\\n  return getDatau_ClusterCenters(addrTranslation_1Dto2D(address1D, u_ClusterCentersSize));\\n}\\nvec4 getDatau_ClusterCenters(int address1D) {\\n  return getDatau_ClusterCenters(float(address1D));\\n}\\nvoid main() {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nint i = globalInvocationID.x;\\nvec4 center = getDatau_ClusterCenters(i);\\nfloat sumx = 0.0;\\nfloat sumy = 0.0;\\nfloat count = 0.0;\\nfor (int j = 0; j < VERTEX_COUNT; j++) {vec4 attributes = getDatau_NodeAttributes(j);\\nint clusterIdx = int(attributes.x);\\nvec4 vertex = getDatau_Data(j);\\nif (clusterIdx == i) {sumx += vertex.x;\\nsumy += vertex.y;\\ncount += 1.0;}}\\ngl_FragColor = vec4(vec4(sumx / count, sumy / count, count, i));if (gWebGPUDebug) {\\n  gl_FragColor = gWebGPUDebugOutput;\\n}}\\n"},"context":{"name":"","dispatch":[1,1,1],"threadGroupSize":[1,1,1],"maxIteration":1,"defines":[{"name":"VERTEX_COUNT","type":"Float","runtime":true},{"name":"CLUSTER_COUNT","type":"Float","runtime":true}],"uniforms":[{"name":"u_Data","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_NodeAttributes","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_ClusterCenters","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":false,"writeonly":false,"size":[1,1]}],"globalDeclarations":[],"output":{"name":"u_ClusterCenters","size":[1,1],"length":1},"needPingpong":true}}`;

--- a/packages/layout-gpu/src/fruchterman.ts
+++ b/packages/layout-gpu/src/fruchterman.ts
@@ -1,0 +1,286 @@
+import {
+  Graph,
+  LayoutMapping,
+  PointTuple,
+  FruchtermanLayoutOptions,
+  Layout,
+  OutNode,
+  cloneFormatData,
+} from "@antv/layout";
+import { World } from "@antv/g-webgpu";
+import { attributesToTextureData, buildTextureData } from "./util";
+import { clusterBundle, fruchtermanBundle } from "./fruchterman-shader";
+import { isNumber } from "@antv/util";
+
+const DEFAULTS_LAYOUT_OPTIONS: Partial<FruchtermanLayoutOptions> = {
+  maxIteration: 1000,
+  gravity: 10,
+  speed: 5,
+  clustering: false,
+  clusterGravity: 10,
+  width: 300,
+  height: 300,
+  nodeClusterBy: "cluster",
+};
+// const SPEED_DIVISOR = 800;
+
+interface FormattedOptions extends FruchtermanLayoutOptions {
+  width: number;
+  height: number;
+  center: PointTuple;
+  maxIteration: number;
+  nodeClusterBy: string;
+  gravity: number;
+  speed: number;
+}
+
+/**
+ * Layout with fructherman force model
+ *
+ * @example
+ * // Assign layout options when initialization.
+ * const layout = new FruchtermanLayout({ center: [100, 100], onLayoutEnd: (positions) => {} });
+ * const positions = layout.execute(graph); // { nodes: [], edges: [] }
+ *
+ * // Or use different options later.
+ * const layout = new FruchtermanLayout({ center: [100, 100], onLayoutEnd: (positions) => {} });
+ * const positions = layout.execute(graph, { center: [100, 100] }); // { nodes: [], edges: [] }
+ *
+ * // If you want to assign the positions directly to the nodes, use assign method.
+ * layout.assign(graph, { center: [100, 100] });
+ */
+export class FruchtermanLayout implements Layout<FruchtermanLayoutOptions> {
+  id = "fruchtermanGPU";
+
+  constructor(
+    public options: FruchtermanLayoutOptions = {} as FruchtermanLayoutOptions
+  ) {
+    this.options = {
+      ...DEFAULTS_LAYOUT_OPTIONS,
+      ...options,
+    };
+  }
+
+  /**
+   * Return the positions of nodes and edges(if needed).
+   */
+  execute(graph: Graph, options?: FruchtermanLayoutOptions): LayoutMapping {
+    return this.genericFruchtermanLayout(
+      false,
+      graph,
+      options
+    ) as LayoutMapping;
+  }
+  /**
+   * To directly assign the positions to the nodes.
+   */
+  assign(graph: Graph, options?: FruchtermanLayoutOptions) {
+    this.genericFruchtermanLayout(true, graph, options);
+  }
+
+  private genericFruchtermanLayout(
+    assign: boolean,
+    graph: Graph,
+    options?: FruchtermanLayoutOptions
+  ): LayoutMapping | void {
+    const formattedOptions = this.formatOptions(options);
+    const {
+      width,
+      height,
+      center,
+      clustering,
+      clusterGravity,
+      nodeClusterBy,
+      maxIteration,
+      gravity,
+      speed,
+      onLayoutEnd,
+    } = formattedOptions;
+
+    let nodes = graph.getAllNodes();
+    let edges = graph.getAllEdges();
+
+    if (!nodes?.length) {
+      const result = { nodes: [], edges };
+      onLayoutEnd?.(result);
+      return result;
+    }
+
+    if (nodes.length === 1) {
+      if (assign) {
+        graph.mergeNodeData(nodes[0].id, {
+          x: center[0],
+          y: center[1],
+        });
+      }
+      const result = {
+        nodes: [
+          {
+            ...nodes[0],
+            data: {
+              ...nodes[0].data,
+              x: center[0],
+              y: center[1],
+            },
+          },
+        ],
+        edges,
+      };
+      onLayoutEnd?.(result);
+      return result;
+    }
+
+    const layoutNodes: OutNode[] = nodes.map(
+      (node) => cloneFormatData(node, [width, height]) as OutNode
+    );
+
+    const area = height * width;
+    let maxDisplace = Math.sqrt(area) / 10;
+    const k2 = area / (layoutNodes.length + 1);
+    const k = Math.sqrt(k2);
+
+    const { array: attributeArray, count: clusterCount } =
+      attributesToTextureData([nodeClusterBy], layoutNodes);
+
+    // pushing the fx and fy
+    layoutNodes.forEach((node, i) => {
+      let fx = 0;
+      let fy = 0;
+      if (isNumber(node.data.fx) && isNumber(node.data.fy)) {
+        fx = (node.data.fx as number) || 0.001;
+        fy = (node.data.fy as number) || 0.001;
+      }
+      attributeArray[4 * i + 1] = fx;
+      attributeArray[4 * i + 2] = fy;
+    });
+
+    const numParticles = layoutNodes.length;
+    const { maxEdgePerVetex, array: nodesEdgesArray } = buildTextureData(
+      layoutNodes,
+      edges
+    );
+
+    const world = World.create({
+      // @ts-ignore
+      engineOptions: {
+        supportCompute: true,
+      },
+    });
+
+    // compile at runtime in dev mode
+    // const compiler = new Compiler()
+    // const fruchtermanBundle = compiler.compileBundle(fruchtermanCode)
+    // const clusterBundle = compiler.compileBundle(clusterCode)
+
+    // use compiled bundle in prod mode
+    // console.log(fruchtermanBundle.toString())
+    // console.log(clusterBundle.toString())
+
+    const clusterCenters: number[] = [];
+    for (let i = 0; i < clusterCount; i++) {
+      clusterCenters.push(0, 0, 0, 0);
+    }
+
+    const kernelFruchterman = world
+      .createKernel(fruchtermanBundle)
+      .setDispatch([numParticles, 1, 1])
+      .setBinding({
+        u_Data: nodesEdgesArray,
+        u_K: k,
+        u_K2: k2,
+        u_Gravity: gravity,
+        u_ClusterGravity: clusterGravity || gravity || 1,
+        u_Speed: speed,
+        u_MaxDisplace: maxDisplace,
+        u_Clustering: clustering ? 1 : 0,
+        u_Center: center,
+        u_AttributeArray: attributeArray,
+        u_ClusterCenters: clusterCenters,
+        MAX_EDGE_PER_VERTEX: maxEdgePerVetex,
+        VERTEX_COUNT: numParticles,
+      });
+
+    let kernelCluster: any;
+    if (clustering) {
+      kernelCluster = world
+        .createKernel(clusterBundle)
+        .setDispatch([clusterCount, 1, 1])
+        .setBinding({
+          u_Data: nodesEdgesArray,
+          u_NodeAttributes: attributeArray,
+          u_ClusterCenters: clusterCenters,
+          VERTEX_COUNT: numParticles,
+          CLUSTER_COUNT: clusterCount,
+        });
+    }
+
+    (async () => {
+      for (let i = 0; i < maxIteration; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await kernelFruchterman.execute();
+
+        if (clustering) {
+          kernelCluster.setBinding({
+            u_Data: kernelFruchterman,
+          });
+          // eslint-disable-next-line no-await-in-loop
+          await kernelCluster.execute();
+          kernelFruchterman.setBinding({
+            u_ClusterCenters: kernelCluster,
+          });
+        }
+
+        kernelFruchterman.setBinding({
+          u_MaxDisplace: (maxDisplace *= 0.99),
+        });
+      }
+
+      const finalParticleData = await kernelFruchterman.getOutput();
+
+      layoutNodes.forEach((node, i) => {
+        node.data.x = finalParticleData[4 * i];
+        node.data.y = finalParticleData[4 * i + 1];
+      });
+      const result = { nodes: layoutNodes, edges };
+
+      if (assign) {
+        layoutNodes.forEach(({ id, data }) =>
+          graph.mergeNodeData(id, {
+            x: data.x,
+            y: data.y,
+          })
+        );
+      }
+
+      onLayoutEnd?.(result);
+    })();
+  }
+
+  private formatOptions(
+    options: FruchtermanLayoutOptions = {}
+  ): FormattedOptions {
+    const mergedOptions = { ...this.options, ...options } as FormattedOptions;
+    const { clustering, nodeClusterBy } = mergedOptions;
+
+    const {
+      center: propsCenter,
+      width: propsWidth,
+      height: propsHeight,
+    } = mergedOptions;
+    mergedOptions.width =
+      !propsWidth && typeof window !== "undefined"
+        ? window.innerWidth
+        : (propsWidth as number);
+    mergedOptions.height =
+      !propsHeight && typeof window !== "undefined"
+        ? window.innerHeight
+        : (propsHeight as number);
+    mergedOptions.center = !propsCenter
+      ? [mergedOptions.width / 2, mergedOptions.height / 2]
+      : (propsCenter as PointTuple);
+
+    mergedOptions.clustering = clustering && !!nodeClusterBy;
+
+    return mergedOptions;
+  }
+}

--- a/packages/layout-gpu/src/gforce-shader.ts
+++ b/packages/layout-gpu/src/gforce-shader.ts
@@ -1,0 +1,220 @@
+export const gForceCode = `
+import { globalInvocationID } from 'g-webgpu';
+
+const MAX_EDGE_PER_VERTEX;
+const VERTEX_COUNT;
+const SHIFT_20 = 1048576;
+
+@numthreads(1, 1, 1)
+class GGForce {
+  @in @out
+  u_Data: vec4[];
+
+  @in
+  u_damping: float;
+  
+  @in
+  u_maxSpeed: float;
+
+  @in
+  u_minMovement: float;
+
+  @in
+  u_AveMovement: vec4[];
+
+  @in
+  u_coulombDisScale: float;
+
+  @in
+  u_factor: float;
+
+  @in
+  u_NodeAttributeArray1: vec4[];
+
+  @in
+  u_NodeAttributeArray2: vec4[];
+
+  @in
+  u_interval: float;
+
+  unpack_float(packedValue: float): ivec2 {
+    const packedIntValue = int(packedValue);
+    const v0 = packedIntValue / SHIFT_20;
+    return [v0, packedIntValue - v0 * SHIFT_20];
+  }
+
+  calcRepulsive(i: int, currentNode: vec4): vec2 {
+    let ax = 0, ay = 0;
+    for (let j: int = 0; j < VERTEX_COUNT; j++) {
+      if (i != j) {
+        const nextNode = this.u_Data[j];
+        const vx = currentNode[0] - nextNode[0];
+        const vy = currentNode[1] - nextNode[1];
+        const dist = sqrt(vx * vx + vy * vy) + 0.01;
+        const n_dist = (dist + 0.1) * this.u_coulombDisScale;
+        const direx = vx / dist;
+        const direy = vy / dist;
+        const attributesi = this.u_NodeAttributeArray1[i];
+        const attributesj = this.u_NodeAttributeArray1[j];
+        const massi = attributesi[0];
+        const nodeStrengthi = attributesi[2];
+        const nodeStrengthj = attributesj[2];
+        const nodeStrength = (nodeStrengthi + nodeStrengthj) / 2;
+        // const param = nodeStrength * this.u_factor / (n_dist * n_dist * massi);
+        const param = nodeStrength * this.u_factor / (n_dist * n_dist);
+        ax += direx * param;
+        ay += direy * param;
+      }
+    }
+    return [ax, ay];
+  }
+
+  calcGravity(i: int, currentNode: vec4, attributes2: vec4): vec2 {
+    // note: attributes2 = [centerX, centerY, gravity, 0]
+
+    const vx = currentNode[0] - attributes2[0];
+    const vy = currentNode[1] - attributes2[1];
+    
+    const ax = vx * attributes2[2];
+    const ay = vy * attributes2[2];
+    
+    return [ax, ay];
+  }
+
+  calcAttractive(i: int, currentNode: vec4, attributes1: vec4): vec2 {
+    // note: attributes1 = [mass, degree, nodeSterngth, 0]
+
+    const mass = attributes1[0];
+    let ax = 0, ay = 0;
+    // const arr_offset = int(floor(currentNode[2] + 0.5));
+    // const length = int(floor(currentNode[3] + 0.5));
+
+    const compressed = this.unpack_float(currentNode[2]);
+    const length = compressed[0];
+    const arr_offset = compressed[1];
+
+    const node_buffer: vec4;
+    for (let p: int = 0; p < MAX_EDGE_PER_VERTEX; p++) {
+      if (p >= length) break;
+      const arr_idx = arr_offset + 4 * p; // i 节点的第 p 条边开始的小格子位置
+      const buf_offset = arr_idx - arr_idx / 4 * 4;
+      if (p == 0 || buf_offset == 0) {
+        node_buffer = this.u_Data[int(arr_idx / 4)]; // 大格子，大格子位置=小个子位置 / 4，
+      }
+
+      let float_j: float = node_buffer[0];
+
+      const nextNode = this.u_Data[int(float_j)];
+      const vx = nextNode[0] - currentNode[0];
+      const vy = nextNode[1] - currentNode[1];
+      const dist = sqrt(vx * vx + vy * vy) + 0.01;
+      const direx = vx / dist;
+      const direy = vy / dist;
+      const edgeLength = node_buffer[1];
+      const edgeStrength = node_buffer[2];
+      const diff: float = edgeLength - dist;//edgeLength
+      // const param = diff * this.u_stiffness / mass; //
+      const param = diff * edgeStrength / mass; // 
+      ax -= direx * param;
+      ay -= direy * param;
+    }
+    return [ax, ay];
+  }
+
+  @main
+  compute() {
+    const i = globalInvocationID.x;
+    const currentNode = this.u_Data[i];
+    const movement = u_AveMovement[0];
+    let ax = 0, ay = 0;
+
+    if (i >= VERTEX_COUNT || movement.x < u_minMovement) {
+      this.u_Data[i] = currentNode;
+      return;
+    }
+
+    // 每个节点属性占两个数组中各一格
+    // [mass, degree, nodeStrength, fx]
+    const nodeAttributes1 = this.u_NodeAttributeArray1[i];
+    // [centerX, centerY, centerGravity, fy]
+    const nodeAttributes2 = this.u_NodeAttributeArray2[i];
+
+    // repulsive
+    const repulsive = this.calcRepulsive(i, currentNode);
+    ax += repulsive[0];
+    ay += repulsive[1];
+
+    // attractive
+    const attractive = this.calcAttractive(i, currentNode, nodeAttributes1);
+    ax += attractive[0];
+    ay += attractive[1];
+
+    // gravity
+    const gravity = this.calcGravity(i, currentNode, nodeAttributes2);
+    ax -= gravity[0];
+    ay -= gravity[1];
+
+    // speed
+    const param = this.u_interval * this.u_damping;
+    let vx = ax * param;
+    let vy = ay * param;
+    const vlength = sqrt(vx * vx + vy * vy) + 0.0001;
+    if (vlength > this.u_maxSpeed) {
+      const param2 = this.u_maxSpeed / vlength;
+      vx = param2 * vx;
+      vy = param2 * vy;
+    }
+
+    // move
+    if (nodeAttributes1[3] != 0 && nodeAttributes2[3] != 0) {
+      this.u_Data[i] = [
+        nodeAttributes1[3],
+        nodeAttributes2[3],
+        currentNode[2],
+        0
+      ];
+    } else {
+      const distx = vx * this.u_interval;
+      const disty = vy * this.u_interval;
+      const distLength = sqrt(distx * distx + disty * disty);
+      this.u_Data[i] = [
+        currentNode[0] + distx,
+        currentNode[1] + disty,
+        currentNode[2],
+        distLength
+      ];
+    }
+    
+    // the avarage move distance
+    // need to share memory
+    
+  }
+}
+`;
+
+export const gForceBundle = `{"shaders":{"WGSL":"","GLSL450":"","GLSL100":"\\n\\nfloat epsilon = 0.00001;\\nvec2 addrTranslation_1Dto2D(float address1D, vec2 texSize) {\\n  vec2 conv_const = vec2(1.0 / texSize.x, 1.0 / (texSize.x * texSize.y));\\n  vec2 normAddr2D = float(address1D) * conv_const;\\n  return vec2(fract(normAddr2D.x + epsilon), normAddr2D.y);\\n}\\n\\nvoid barrier() {}\\n  \\n\\nuniform vec2 u_OutputTextureSize;\\nuniform int u_OutputTexelCount;\\nvarying vec2 v_TexCoord;\\n\\nbool gWebGPUDebug = false;\\nvec4 gWebGPUDebugOutput = vec4(0.0);\\n\\n#define MAX_EDGE_PER_VERTEX __DefineValuePlaceholder__MAX_EDGE_PER_VERTEX\\n#define VERTEX_COUNT __DefineValuePlaceholder__VERTEX_COUNT\\n#define SHIFT_20 1048576.0\\n\\nuniform sampler2D u_Data;\\nuniform vec2 u_DataSize;\\nvec4 getDatau_Data(vec2 address2D) {\\n  return vec4(texture2D(u_Data, address2D).rgba);\\n}\\nvec4 getDatau_Data(float address1D) {\\n  return getDatau_Data(addrTranslation_1Dto2D(address1D, u_DataSize));\\n}\\nvec4 getDatau_Data(int address1D) {\\n  return getDatau_Data(float(address1D));\\n}\\nuniform float u_damping;\\nuniform float u_maxSpeed;\\nuniform float u_minMovement;\\nuniform sampler2D u_AveMovement;\\nuniform vec2 u_AveMovementSize;\\nvec4 getDatau_AveMovement(vec2 address2D) {\\n  return vec4(texture2D(u_AveMovement, address2D).rgba);\\n}\\nvec4 getDatau_AveMovement(float address1D) {\\n  return getDatau_AveMovement(addrTranslation_1Dto2D(address1D, u_AveMovementSize));\\n}\\nvec4 getDatau_AveMovement(int address1D) {\\n  return getDatau_AveMovement(float(address1D));\\n}\\nuniform float u_coulombDisScale;\\nuniform float u_factor;\\nuniform sampler2D u_NodeAttributeArray1;\\nuniform vec2 u_NodeAttributeArray1Size;\\nvec4 getDatau_NodeAttributeArray1(vec2 address2D) {\\n  return vec4(texture2D(u_NodeAttributeArray1, address2D).rgba);\\n}\\nvec4 getDatau_NodeAttributeArray1(float address1D) {\\n  return getDatau_NodeAttributeArray1(addrTranslation_1Dto2D(address1D, u_NodeAttributeArray1Size));\\n}\\nvec4 getDatau_NodeAttributeArray1(int address1D) {\\n  return getDatau_NodeAttributeArray1(float(address1D));\\n}\\nuniform sampler2D u_NodeAttributeArray2;\\nuniform vec2 u_NodeAttributeArray2Size;\\nvec4 getDatau_NodeAttributeArray2(vec2 address2D) {\\n  return vec4(texture2D(u_NodeAttributeArray2, address2D).rgba);\\n}\\nvec4 getDatau_NodeAttributeArray2(float address1D) {\\n  return getDatau_NodeAttributeArray2(addrTranslation_1Dto2D(address1D, u_NodeAttributeArray2Size));\\n}\\nvec4 getDatau_NodeAttributeArray2(int address1D) {\\n  return getDatau_NodeAttributeArray2(float(address1D));\\n}\\nuniform float u_interval;\\nivec2 unpack_float(float packedValue) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nint packedIntValue = int(packedValue);\\nint v0 = packedIntValue / int(SHIFT_20);\\nreturn ivec2(v0, packedIntValue - (v0 * int(SHIFT_20)));}\\nvec2 calcRepulsive(int i, vec4 currentNode) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat ax = 0.0;\\nfloat ay = 0.0;\\nfor (int j = 0; j < VERTEX_COUNT; j++) {if (i != j) {vec4 nextNode = getDatau_Data(j);\\nfloat vx = currentNode.x - nextNode.x;\\nfloat vy = currentNode.y - nextNode.y;\\nfloat dist = sqrt((vx * vx) + (vy * vy)) + 0.01;\\nfloat n_dist = (dist + 0.1) * u_coulombDisScale;\\nfloat direx = vx / dist;\\nfloat direy = vy / dist;\\nvec4 attributesi = getDatau_NodeAttributeArray1(i);\\nvec4 attributesj = getDatau_NodeAttributeArray1(j);\\nfloat massi = attributesi.x;\\nfloat nodeStrengthi = attributesi.z;\\nfloat nodeStrengthj = attributesj.z;\\nfloat nodeStrength = (nodeStrengthi + nodeStrengthj) / 2.0;\\nfloat param = (nodeStrength * u_factor) / (n_dist * n_dist);\\nax += direx * param;\\nay += direy * param;}}\\nreturn vec2(ax, ay);}\\nvec2 calcGravity(int i, vec4 currentNode, vec4 attributes2) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat vx = currentNode.x - attributes2.x;\\nfloat vy = currentNode.y - attributes2.y;\\nfloat ax = vx * attributes2.z;\\nfloat ay = vy * attributes2.z;\\nreturn vec2(ax, ay);}\\nvec2 calcAttractive(int i, vec4 currentNode, vec4 attributes1) {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat mass = attributes1.x;\\nfloat ax = 0.0;\\nfloat ay = 0.0;\\nivec2 compressed = unpack_float(currentNode.z);\\nint length = compressed.x;\\nint arr_offset = compressed.y;\\nvec4 node_buffer;\\nfor (int p = 0; p < MAX_EDGE_PER_VERTEX; p++) {if (p >= length) {break;}\\nint arr_idx = arr_offset + (4 * p);\\nint buf_offset = arr_idx - ((arr_idx / 4) * 4);\\nif ((p == 0) || (buf_offset == 0)) {node_buffer = getDatau_Data(int(arr_idx / 4));}\\nfloat float_j = node_buffer.x;\\nvec4 nextNode = getDatau_Data(int(float_j));\\nfloat vx = nextNode.x - currentNode.x;\\nfloat vy = nextNode.y - currentNode.y;\\nfloat dist = sqrt((vx * vx) + (vy * vy)) + 0.01;\\nfloat direx = vx / dist;\\nfloat direy = vy / dist;\\nfloat edgeLength = node_buffer.y;\\nfloat edgeStrength = node_buffer.z;\\nfloat diff = edgeLength - dist;\\nfloat param = (diff * edgeStrength) / mass;\\nax -= direx * param;\\nay -= direy * param;}\\nreturn vec2(ax, ay);}\\nvoid main() {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nint i = globalInvocationID.x;\\nvec4 currentNode = getDatau_Data(i);\\nvec4 movement = getDatau_AveMovement(0.0);\\nfloat ax = 0.0;\\nfloat ay = 0.0;\\nif ((i >= VERTEX_COUNT) || (movement.x < u_minMovement)) {gl_FragColor = vec4(currentNode);\\nreturn ;}\\nvec4 nodeAttributes1 = getDatau_NodeAttributeArray1(i);\\nvec4 nodeAttributes2 = getDatau_NodeAttributeArray2(i);\\nvec2 repulsive = calcRepulsive(i, currentNode);\\nax += repulsive.x;\\nay += repulsive.y;\\nvec2 attractive = calcAttractive(i, currentNode, nodeAttributes1);\\nax += attractive.x;\\nay += attractive.y;\\nvec2 gravity = calcGravity(i, currentNode, nodeAttributes2);\\nax -= gravity.x;\\nay -= gravity.y;\\nfloat param = u_interval * u_damping;\\nfloat vx = ax * param;\\nfloat vy = ay * param;\\nfloat vlength = sqrt((vx * vx) + (vy * vy)) + 0.0001;\\nif (vlength > u_maxSpeed) {float param2 = u_maxSpeed / vlength;\\nvx = param2 * vx;\\nvy = param2 * vy;}\\nif ((nodeAttributes1.w != 0.0) && (nodeAttributes2.w != 0.0)) {gl_FragColor = vec4(vec4(nodeAttributes1.w, nodeAttributes2.w, currentNode.z, 0.0));}else {float distx = vx * u_interval;\\nfloat disty = vy * u_interval;\\nfloat distLength = sqrt((distx * distx) + (disty * disty));\\ngl_FragColor = vec4(vec4(currentNode.x + distx, currentNode.y + disty, currentNode.z, distLength));}if (gWebGPUDebug) {\\n  gl_FragColor = gWebGPUDebugOutput;\\n}}\\n"},"context":{"name":"","dispatch":[1,1,1],"threadGroupSize":[1,1,1],"maxIteration":1,"defines":[{"name":"MAX_EDGE_PER_VERTEX","type":"Float","runtime":true},{"name":"VERTEX_COUNT","type":"Float","runtime":true},{"name":"SHIFT_20","type":"Float","value":1048576,"runtime":false}],"uniforms":[{"name":"u_Data","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":false,"writeonly":false,"size":[1,1]},{"name":"u_damping","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_maxSpeed","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_minMovement","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_AveMovement","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_coulombDisScale","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_factor","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_NodeAttributeArray1","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_NodeAttributeArray2","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_interval","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]}],"globalDeclarations":[],"output":{"name":"u_Data","size":[1,1],"length":1},"needPingpong":true}}`;
+
+export const aveMovementCode = `
+const VERTEX_COUNT;
+@numthreads(1, 1, 1)
+class CalcAveMovement {
+  @in
+  u_Data: vec4[];
+  @in
+  u_iter: float;
+  @in @out
+  u_AveMovement: vec4[];
+  @main
+  compute() {
+    let movement = 0;
+    for (let j: int = 0; j < VERTEX_COUNT; j++) {
+      const vertex = this.u_Data[j];
+      movement += vertex[3];
+    }
+    movement = movement / float(VERTEX_COUNT);
+    this.u_AveMovement[0] = [movement, 0, 0, 0];
+  }
+}
+`;
+
+export const aveMovementBundle = `{"shaders":{"WGSL":"","GLSL450":"","GLSL100":"\\n\\nfloat epsilon = 0.00001;\\nvec2 addrTranslation_1Dto2D(float address1D, vec2 texSize) {\\n  vec2 conv_const = vec2(1.0 / texSize.x, 1.0 / (texSize.x * texSize.y));\\n  vec2 normAddr2D = float(address1D) * conv_const;\\n  return vec2(fract(normAddr2D.x + epsilon), normAddr2D.y);\\n}\\n\\nvoid barrier() {}\\n  \\n\\nuniform vec2 u_OutputTextureSize;\\nuniform int u_OutputTexelCount;\\nvarying vec2 v_TexCoord;\\n\\nbool gWebGPUDebug = false;\\nvec4 gWebGPUDebugOutput = vec4(0.0);\\n\\n#define VERTEX_COUNT __DefineValuePlaceholder__VERTEX_COUNT\\n\\nuniform sampler2D u_Data;\\nuniform vec2 u_DataSize;\\nvec4 getDatau_Data(vec2 address2D) {\\n  return vec4(texture2D(u_Data, address2D).rgba);\\n}\\nvec4 getDatau_Data(float address1D) {\\n  return getDatau_Data(addrTranslation_1Dto2D(address1D, u_DataSize));\\n}\\nvec4 getDatau_Data(int address1D) {\\n  return getDatau_Data(float(address1D));\\n}\\nuniform float u_iter;\\nuniform sampler2D u_AveMovement;\\nuniform vec2 u_AveMovementSize;\\nvec4 getDatau_AveMovement(vec2 address2D) {\\n  return vec4(texture2D(u_AveMovement, address2D).rgba);\\n}\\nvec4 getDatau_AveMovement(float address1D) {\\n  return getDatau_AveMovement(addrTranslation_1Dto2D(address1D, u_AveMovementSize));\\n}\\nvec4 getDatau_AveMovement(int address1D) {\\n  return getDatau_AveMovement(float(address1D));\\n}\\nvoid main() {\\nivec3 workGroupSize = ivec3(1, 1, 1);\\nivec3 numWorkGroups = ivec3(1, 1, 1);     \\nint globalInvocationIndex = int(floor(v_TexCoord.x * u_OutputTextureSize.x))\\n  + int(floor(v_TexCoord.y * u_OutputTextureSize.y)) * int(u_OutputTextureSize.x);\\nint workGroupIDLength = globalInvocationIndex / (workGroupSize.x * workGroupSize.y * workGroupSize.z);\\nivec3 workGroupID = ivec3(workGroupIDLength / numWorkGroups.y / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.z, workGroupIDLength / numWorkGroups.x / numWorkGroups.y);\\nint localInvocationIDZ = globalInvocationIndex / (workGroupSize.x * workGroupSize.y);\\nint localInvocationIDY = (globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y) / workGroupSize.x;\\nint localInvocationIDX = globalInvocationIndex - localInvocationIDZ * workGroupSize.x * workGroupSize.y - localInvocationIDY * workGroupSize.x;\\nivec3 localInvocationID = ivec3(localInvocationIDX, localInvocationIDY, localInvocationIDZ);\\nivec3 globalInvocationID = workGroupID * workGroupSize + localInvocationID;\\nint localInvocationIndex = localInvocationID.z * workGroupSize.x * workGroupSize.y\\n                + localInvocationID.y * workGroupSize.x + localInvocationID.x;\\nfloat movement = 0.0;\\nfor (int j = 0; j < VERTEX_COUNT; j++) {vec4 vertex = getDatau_Data(j);\\nmovement += vertex.w;}\\nmovement = movement / float(VERTEX_COUNT);\\ngl_FragColor = vec4(vec4(movement, 0.0, 0.0, 0.0));if (gWebGPUDebug) {\\n  gl_FragColor = gWebGPUDebugOutput;\\n}}\\n"},"context":{"name":"","dispatch":[1,1,1],"threadGroupSize":[1,1,1],"maxIteration":1,"defines":[{"name":"VERTEX_COUNT","type":"Float","runtime":true}],"uniforms":[{"name":"u_Data","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_iter","type":"Float","storageClass":"Uniform","readonly":true,"writeonly":false,"size":[1,1]},{"name":"u_AveMovement","type":"vec4<f32>[]","storageClass":"StorageBuffer","readonly":false,"writeonly":false,"size":[1,1]}],"globalDeclarations":[],"output":{"name":"u_AveMovement","size":[1,1],"length":1},"needPingpong":true}}`;

--- a/packages/layout-gpu/src/gforce.ts
+++ b/packages/layout-gpu/src/gforce.ts
@@ -1,0 +1,365 @@
+import { World } from "@antv/g-webgpu";
+import {
+  Graph,
+  Node,
+  Edge,
+  LayoutMapping,
+  ForceLayoutOptions,
+  OutNode,
+  Layout,
+  PointTuple,
+  cloneFormatData,
+  formatNumberFn,
+} from "@antv/layout";
+import { isNumber } from "@antv/util";
+import { aveMovementBundle, gForceBundle } from "./gforce-shader";
+import { arrayToTextureData, buildTextureDataWithTwoEdgeAttr } from "./util";
+
+const DEFAULTS_LAYOUT_OPTIONS: Partial<ForceLayoutOptions> = {
+  linkDistance: 1,
+  nodeStrength: 1000,
+  maxIteration: 1000,
+  edgeStrength: 200,
+  coulombDisScale: 0.005,
+  damping: 0.9,
+  maxSpeed: 1000,
+  minMovement: 0.5,
+  interval: 0.02,
+  factor: 1,
+  gravity: 10,
+};
+
+interface FormattedOptions extends ForceLayoutOptions {
+  width: number;
+  height: number;
+  center: PointTuple;
+  maxIteration: number;
+  gravity: number;
+  damping: number;
+  maxSpeed: number;
+  minMovement: number;
+  coulombDisScale: number;
+  factor: number;
+  interval: number;
+  nodeSize: (d?: Node) => number;
+  getMass: (d?: Node) => number;
+  nodeStrength: (d?: Node) => number;
+  edgeStrength: (d?: Edge) => number;
+  linkDistance: (edge?: Edge, source?: any, target?: any) => number;
+}
+
+/**
+ * Layout with faster force
+ *
+ * @example
+ * // Assign layout options when initialization.
+ * const layout = new GForceLayout({ center: [100, 100], onLayoutEnd: (positions) => {} });
+ * const positions = layout.execute(graph); // { nodes: [], edges: [] }
+ *
+ * // Or use different options later.
+ * const layout = new GForceLayout({ center: [100, 100], onLayoutEnd: (positions) => {} });
+ * const positions = layout.execute(graph, { center: [100, 100] }); // { nodes: [], edges: [] }
+ *
+ * // If you want to assign the positions directly to the nodes, use assign method.
+ * layout.assign(graph, { center: [100, 100] });
+ */
+export class GForceLayout implements Layout<ForceLayoutOptions> {
+  id = "gforce";
+
+  constructor(public options: ForceLayoutOptions = {} as ForceLayoutOptions) {
+    this.options = {
+      ...DEFAULTS_LAYOUT_OPTIONS,
+      ...options,
+    };
+  }
+
+  /**
+   * Return the positions of nodes and edges(if needed).
+   */
+  execute(graph: Graph, options?: ForceLayoutOptions): LayoutMapping {
+    return this.genericForceLayout(false, graph, options) as LayoutMapping;
+  }
+  /**
+   * To directly assign the positions to the nodes.
+   */
+  assign(graph: Graph, options?: ForceLayoutOptions) {
+    this.genericForceLayout(true, graph, options);
+  }
+
+  private genericForceLayout(
+    assign: boolean,
+    graph: Graph,
+    options?: ForceLayoutOptions
+  ): LayoutMapping | void {
+    const formattedOptions = this.formatOptions(options, graph);
+    const {
+      width,
+      height,
+      center,
+      gravity,
+      linkDistance,
+      edgeStrength,
+      onLayoutEnd,
+      getMass,
+      getCenter,
+      nodeStrength,
+      damping,
+      maxSpeed,
+      minMovement,
+      coulombDisScale,
+      factor,
+      interval,
+      maxIteration,
+    } = formattedOptions;
+
+    let nodes = graph.getAllNodes();
+    let edges = graph.getAllEdges();
+
+    if (!nodes?.length) {
+      const result = { nodes: [], edges };
+      onLayoutEnd?.(result);
+      return result;
+    }
+
+    if (nodes.length === 1) {
+      if (assign) {
+        graph.mergeNodeData(nodes[0].id, {
+          x: center[0],
+          y: center[1],
+        });
+      }
+      const result = {
+        nodes: [
+          {
+            ...nodes[0],
+            data: {
+              ...nodes[0].data,
+              x: center[0],
+              y: center[1],
+            },
+          },
+        ],
+        edges,
+      };
+      onLayoutEnd?.(result);
+      return result;
+    }
+
+    const layoutNodes: OutNode[] = nodes.map(
+      (node) => cloneFormatData(node, [width, height]) as OutNode
+    );
+    layoutNodes.forEach((node, i) => {
+      if (!isNumber(node.data.x)) node.data.x = Math.random() * width;
+      if (!isNumber(node.data.y)) node.data.y = Math.random() * height;
+    });
+
+    const numParticles = layoutNodes.length;
+
+    const { maxEdgePerVetex, array: nodesEdgesArray } =
+      buildTextureDataWithTwoEdgeAttr(
+        layoutNodes,
+        edges,
+        linkDistance,
+        edgeStrength
+      );
+
+    const masses: number[] = [];
+    const nodeStrengths: number[] = [];
+    const centerXs: number[] = [];
+    const centerYs: number[] = [];
+    const centerGravities: number[] = [];
+    const fxs: number[] = [];
+    const fys: number[] = [];
+    const degrees = layoutNodes.map((node) => graph.getDegree(node.id, "both"));
+
+    layoutNodes.forEach((node, i) => {
+      masses.push(getMass(node));
+      nodeStrengths.push(nodeStrength(node));
+
+      let nodeGravity = [center[0], center[1], gravity];
+      if (getCenter) {
+        const customCenter = getCenter(node, degrees[i]);
+        if (
+          customCenter &&
+          isNumber(customCenter[0]) &&
+          isNumber(customCenter[1]) &&
+          isNumber(customCenter[2])
+        ) {
+          nodeGravity = customCenter;
+        }
+      }
+      centerXs.push(nodeGravity[0]);
+      centerYs.push(nodeGravity[1]);
+      centerGravities.push(nodeGravity[2]);
+      if (isNumber(node.data.fx) && isNumber(node.data.fy)) {
+        fxs.push(node.data.fx || 0.001);
+        fys.push(node.data.fy || 0.001);
+      } else {
+        fxs.push(0);
+        fys.push(0);
+      }
+    });
+
+    // 每个节点的额外属性占两个数组各一格，nodeAttributeArray1 中是：mass, degree, nodeSterngth, 0
+    const nodeAttributeArray1 = arrayToTextureData([
+      masses,
+      degrees,
+      nodeStrengths,
+      fxs,
+    ]);
+    // nodeAttributeArray2 中是：centerX, centerY, gravity, 0,
+    const nodeAttributeArray2 = arrayToTextureData([
+      centerXs,
+      centerYs,
+      centerGravities,
+      fys,
+    ]);
+
+    const world = World.create({
+      // @ts-ignore
+      engineOptions: {
+        supportCompute: true,
+      },
+    });
+
+    //最终的预编译代码放入到 gForceShader.ts 中直接引入，不再需要下面三行
+    // const compiler = new Compiler();
+    // const gForceBundle = compiler.compileBundle(gForceCode);
+    // console.log(gForceBundle.toString());
+
+    const initPreviousData = [];
+    nodesEdgesArray.forEach((value) => {
+      initPreviousData.push(value);
+    });
+    for (let i = 0; i < 4; i++) {
+      initPreviousData.push(0);
+    }
+
+    const kernelGForce = world
+      .createKernel(gForceBundle)
+      .setDispatch([numParticles, 1, 1])
+      .setBinding({
+        u_Data: nodesEdgesArray, // 节点边输入输出
+        u_damping: damping,
+        u_maxSpeed: maxSpeed,
+        u_minMovement: minMovement,
+        u_coulombDisScale: coulombDisScale,
+        u_factor: factor,
+        u_NodeAttributeArray1: nodeAttributeArray1,
+        u_NodeAttributeArray2: nodeAttributeArray2,
+        MAX_EDGE_PER_VERTEX: maxEdgePerVetex,
+        VERTEX_COUNT: numParticles,
+        u_AveMovement: initPreviousData,
+        u_interval: interval, // 每次迭代更新，首次设置为 interval，在 onIterationCompleted 中更新
+      });
+
+    // const aveMovementBundle = compiler.compileBundle(aveMovementCode);
+    // console.log(aveMovementBundle.toString());
+
+    const kernelAveMovement = world
+      .createKernel(aveMovementBundle)
+      .setDispatch([1, 1, 1])
+      .setBinding({
+        u_Data: nodesEdgesArray,
+        VERTEX_COUNT: numParticles,
+        u_AveMovement: [0, 0, 0, 0],
+      });
+
+    (async () => {
+      for (let i = 0; i < maxIteration; i++) {
+        // TODO: 似乎都来自 kernelGForce 是一个引用
+        // 当前坐标作为下一次迭代的 PreviousData
+        // if (i > 0) {
+        //   kernelAveMovement.setBinding({
+        //     u_PreviousData: kernelGForce
+        //   });
+        // }
+
+        // eslint-disable-next-line no-await-in-loop
+        await kernelGForce.execute();
+
+        // midRes = await kernelGForce.getOutput();
+
+        // 每次迭代完成后
+        // 计算平均位移，用于提前终止迭代
+        kernelAveMovement.setBinding({
+          // @ts-ignore
+          u_Data: kernelGForce,
+        });
+
+        // eslint-disable-next-line no-await-in-loop
+        await kernelAveMovement.execute();
+
+        // 更新衰减函数
+        const stepInterval = Math.max(0.02, interval - i * 0.002);
+        kernelGForce.setBinding({
+          u_interval: stepInterval,
+          // @ts-ignore
+          u_AveMovement: kernelAveMovement,
+        });
+      }
+      const finalParticleData = await kernelGForce.getOutput();
+
+      layoutNodes.forEach((node, i) => {
+        node.data.x = finalParticleData[4 * i];
+        node.data.y = finalParticleData[4 * i + 1];
+      });
+      const result = { nodes: layoutNodes, edges };
+
+      if (assign) {
+        layoutNodes.forEach(({ id, data }) =>
+          graph.mergeNodeData(id, {
+            x: data.x,
+            y: data.y,
+          })
+        );
+      }
+
+      onLayoutEnd?.(result);
+    })();
+  }
+
+  private formatOptions(
+    options: ForceLayoutOptions = {},
+    graph: Graph
+  ): FormattedOptions {
+    const formattedOptions = {
+      ...this.options,
+      ...options,
+    } as FormattedOptions;
+    const { width: propsWidth, height: propsHeight, getMass } = options;
+
+    // === formating width, height, and center =====
+    formattedOptions.width =
+      !propsWidth && typeof window !== "undefined"
+        ? window.innerWidth
+        : (propsWidth as number);
+    formattedOptions.height =
+      !propsHeight && typeof window !== "undefined"
+        ? window.innerHeight
+        : (propsHeight as number);
+    if (!options.center) {
+      formattedOptions.center = [
+        formattedOptions.width / 2,
+        formattedOptions.height / 2,
+      ];
+    }
+
+    // === formating node mass =====
+    if (!getMass) {
+      formattedOptions.getMass = (d?: Node) => {
+        let massWeight = 1;
+        if (isNumber(d?.data.mass)) massWeight = d?.data.mass as number;
+        const degree = graph.getDegree(d!.id, "both");
+        return !degree || degree < 5 ? massWeight : degree * 5 * massWeight;
+      };
+    }
+
+    // === formating node / edge strengths =====
+    formattedOptions.linkDistance = formatNumberFn(1, options.linkDistance);
+    formattedOptions.nodeStrength = formatNumberFn(1, options.nodeStrength);
+    formattedOptions.edgeStrength = formatNumberFn(1, options.edgeStrength);
+
+    return formattedOptions;
+  }
+}

--- a/packages/layout-gpu/src/index.ts
+++ b/packages/layout-gpu/src/index.ts
@@ -1,0 +1,9 @@
+import { registerLayout } from "@antv/layout";
+import { FruchtermanLayout } from "./fruchterman";
+import { GForceLayout } from "./gforce";
+
+registerLayout("fruchtermanGPU", FruchtermanLayout);
+registerLayout("gforce", GForceLayout);
+
+export * from "./fruchterman";
+export * from "./gforce";

--- a/packages/layout-gpu/src/util.ts
+++ b/packages/layout-gpu/src/util.ts
@@ -1,0 +1,175 @@
+import { Node, Edge, IndexMap } from "@antv/layout";
+
+export const attributesToTextureData = (
+  attributeNames: string[],
+  items: any[]
+): { array: Float32Array; count: number } => {
+  const dataArray: any[] = [];
+  const attributeNum = attributeNames.length;
+  const attributteStringMap: any = {};
+  items.forEach((item: any) => {
+    attributeNames.forEach((name: string, i) => {
+      if (attributteStringMap[item[name]] === undefined) {
+        attributteStringMap[item[name]] =
+          Object.keys(attributteStringMap).length;
+      }
+      dataArray.push(attributteStringMap[item[name]]);
+      // insure each node's attributes take inter number of grids
+      if (i === attributeNum - 1) {
+        while (dataArray.length % 4 !== 0) {
+          dataArray.push(0);
+        }
+      }
+    });
+  });
+  return {
+    array: new Float32Array(dataArray),
+    count: Object.keys(attributteStringMap).length,
+  };
+};
+
+/**
+ * 将节点和边数据转换为 GPU 可读的数组。并返回 maxEdgePerVetex，每个节点上最多的边数
+ * @param  {NodeConfig[]}  nodes 需要被转换的值
+ * @param  {EdgeConfig[]}  edges 返回函数的默认返回值
+ * @return {Object} 转换后的数组及 maxEdgePerVetex 组成的对象
+ */
+export const buildTextureData = (
+  nodes: Node[],
+  edges: Edge[]
+): {
+  array: Float32Array;
+  maxEdgePerVetex: number;
+} => {
+  const dataArray: number[] = [];
+  const nodeDict: any = [];
+  const mapIdPos: IndexMap = {};
+  let i = 0;
+  for (i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    mapIdPos[n.id] = i;
+    dataArray.push(n.data.x as number);
+    dataArray.push(n.data.y as number);
+    dataArray.push(0);
+    dataArray.push(0);
+    nodeDict.push([]);
+  }
+  for (i = 0; i < edges.length; i++) {
+    const e = edges[i];
+    const source = e.source;
+    const target = e.target;
+    if (!isNaN(mapIdPos[source]) && !isNaN(mapIdPos[target])) {
+      nodeDict[mapIdPos[source]].push(mapIdPos[target]);
+      nodeDict[mapIdPos[target]].push(mapIdPos[source]);
+    }
+  }
+
+  let maxEdgePerVetex = 0;
+  for (i = 0; i < nodes.length; i++) {
+    const offset: number = dataArray.length;
+    const dests = nodeDict[i];
+    const len = dests.length;
+    dataArray[i * 4 + 2] = offset;
+    dataArray[i * 4 + 3] = len;
+    maxEdgePerVetex = Math.max(maxEdgePerVetex, len);
+    for (let j = 0; j < len; ++j) {
+      const dest = dests[j];
+      dataArray.push(+dest);
+    }
+  }
+
+  while (dataArray.length % 4 !== 0) {
+    dataArray.push(0);
+  }
+  return {
+    maxEdgePerVetex,
+    array: new Float32Array(dataArray),
+  };
+};
+
+export const buildTextureDataWithTwoEdgeAttr = (
+  nodes: Node[],
+  edges: Edge[],
+  attrs1: (e: Edge) => number,
+  attrs2: (e: Edge) => number
+): {
+  array: Float32Array;
+  maxEdgePerVetex: number;
+} => {
+  const dataArray: number[] = [];
+  const nodeDict: any = [];
+  const mapIdPos: IndexMap = {};
+  let i = 0;
+  for (i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    mapIdPos[n.id] = i;
+    dataArray.push(n.data.x as number);
+    dataArray.push(n.data.y as number);
+    dataArray.push(0);
+    dataArray.push(0);
+    nodeDict.push([]);
+  }
+  for (i = 0; i < edges.length; i++) {
+    const e = edges[i];
+    const source = e.source;
+    const target = e.target;
+    nodeDict[mapIdPos[source]].push(mapIdPos[target]);
+    nodeDict[mapIdPos[source]].push(attrs1(e));
+    nodeDict[mapIdPos[source]].push(attrs2(e));
+    nodeDict[mapIdPos[source]].push(0);
+    nodeDict[mapIdPos[target]].push(mapIdPos[source]);
+    nodeDict[mapIdPos[target]].push(attrs1(e));
+    nodeDict[mapIdPos[target]].push(attrs2(e));
+    nodeDict[mapIdPos[target]].push(0);
+  }
+
+  let maxEdgePerVetex = 0;
+  for (i = 0; i < nodes.length; i++) {
+    const offset: number = dataArray.length;
+    const dests = nodeDict[i]; // dest 中节点 id 与边长间隔存储，即一位节点 id，一位边长……
+    const len = dests.length;
+    // dataArray[i * 4 + 2] = offset;
+    // dataArray[i * 4 + 3] = len / 4; // 第四位存储与该节点相关的所有节点个数
+    // pack offset & length into float32: offset 20bit, length 12bit
+    dataArray[i * 4 + 2] = offset + (1048576 * len) / 4;
+    dataArray[i * 4 + 3] = 0; // 第四位存储与上一次的距离差值
+    maxEdgePerVetex = Math.max(maxEdgePerVetex, len / 4);
+    for (let j = 0; j < len; ++j) {
+      const dest = dests[j];
+      dataArray.push(+dest);
+    }
+  }
+
+  // 不是 4 的倍数，填充 0
+  while (dataArray.length % 4 !== 0) {
+    dataArray.push(0);
+  }
+  return {
+    maxEdgePerVetex,
+    array: new Float32Array(dataArray),
+  };
+};
+
+/**
+ * transform the number array format of extended attributes of nodes or edges to a texture array
+ * @param  {string[]}  attributeNames attributes' name to be read from items and put into output array
+ * @return {Float32Array} the attributes' value array to be read by GPU
+ */
+export const arrayToTextureData = (valueArrays: number[][]): Float32Array => {
+  const dataArray: any[] = [];
+  const attributeNum = valueArrays.length;
+  const itemNum = valueArrays[0].length;
+  for (let j = 0; j < itemNum; j++) {
+    valueArrays.forEach((valueArray, i) => {
+      dataArray.push(valueArray[j]);
+      // insure each node's attributes take inter number of grids
+      if (i === attributeNum - 1) {
+        while (dataArray.length % 4 !== 0) {
+          dataArray.push(0);
+        }
+      }
+    });
+  }
+
+  return new Float32Array(dataArray);
+};

--- a/packages/layout-gpu/tsconfig.json
+++ b/packages/layout-gpu/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "composite": true,
+    "module": "esnext",
+    "declaration": true,
+    "sourceMap": true,
+    "target": "es5",
+    "outDir": "lib",
+    "jsx": "react",
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
+    "types": ["jest"],
+    "experimentalDecorators": false /* Enables experimental support for ES7 decorators. */,
+    // "emitDecoratorMetadata": true, /* Enables experimental support for emitting type metadata for decorators. */
+    "downlevelIteration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.ts"]
+}

--- a/packages/layout-gpu/webpack.config.js
+++ b/packages/layout-gpu/webpack.config.js
@@ -10,7 +10,12 @@ module.exports = {
     clean: true,
   },
   externals: {
-    "@antv/layout": "Layout",
+    "@antv/layout": {
+      commonjs: "@antv/layout@alpha",
+      commonjs2: "@antv/layout@alpha",
+      amd: "@antv/layout@alpha",
+      root: "Layout", // indicates global variable
+    },
   },
   resolve: {
     // Add `.ts` as a resolvable extension.

--- a/packages/layout-gpu/webpack.config.js
+++ b/packages/layout-gpu/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index.ts",
+  output: {
+    filename: "index.min.js",
+    path: path.resolve(__dirname, "dist"),
+    library: "LayoutGPU",
+    libraryTarget: "umd",
+    clean: true,
+  },
+  externals: {
+    "@antv/layout": "Layout",
+  },
+  resolve: {
+    // Add `.ts` as a resolvable extension.
+    extensions: [".ts", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devtool: "source-map",
+};

--- a/packages/layout-gpu/webpack.dev.config.js
+++ b/packages/layout-gpu/webpack.dev.config.js
@@ -1,0 +1,14 @@
+const webpackConfig = require('./webpack.config');
+
+module.exports = Object.assign(
+  {
+    devtool: 'cheap-source-map',
+    watch: true,
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000,
+      ignored: /node_modules/
+    },
+  },
+  webpackConfig,
+);

--- a/packages/layout-gpu/webpack.esm.config.js
+++ b/packages/layout-gpu/webpack.esm.config.js
@@ -1,0 +1,30 @@
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index.ts",
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    library: {
+      type: "module",
+    },
+    path: path.resolve(__dirname, "esm"),
+    filename: "index.esm.js",
+    clean: true,
+  },
+  resolve: {
+    // Add `.ts` as a resolvable extension.
+    extensions: [".ts", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devtool: "source-map",
+};

--- a/packages/layout-rust/README.md
+++ b/packages/layout-rust/README.md
@@ -1,3 +1,5 @@
+# @antv/layout-rust
+
 ## Examples
 
 All examples are already places in the `examples/` directory:

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -1,8 +1,8 @@
 # @antv/layout
 
-Collection of basic layout algorithms to be used with [@antv/graphlib]().
+Collection of basic layout algorithms to be used with [@antv/graphlib](https://www.npmjs.com/package/@antv/graphlib).
 
-[Living Demo](https://observablehq.com/d/2db6b0cc5e97d8d6)
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6)
 
 ## Usage
 
@@ -59,9 +59,25 @@ const { CircularLayout } = window.Layout;
 
 ## Documentation
 
-- [G6 Layout](https://g6.antv.vision/zh/docs/api/graphLayout/guide)
+We provide the following layouts:
 
-Layout algorithms can be divided into two categories, the first is synchronous, e.g. circular layout
+- [Circular](#Circular)
+- [Random](#Random)
+- [Grid](#Grid)
+- [MDS](#MDS)
+- [Concentric](#Concentric)
+- [Radial](#Radial)
+- [Fruchterman](#Fruchterman)
+- [D3Force](#D3Force)
+- [Force](#Force)
+- [ForceAtlas2](#ForceAtlas2)
+
+You can choose the following two ways to use, the difference is whether to change the node & edge data in the graph model:
+
+- Calling execute to return positions of nodes & edges.
+- Or calling assign to directly assign the positions to the nodes in graph model.
+
+The first argument is the target `graph` whose type is **Graph**.
 
 ### Circular
 
@@ -71,28 +87,208 @@ Circular layout arranges the node on a circle. By tuning the configurations, use
 <img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*_nLORItzM5QAAAAAAAAAAABkARQnAQ" alt="circular layout" width="300">
 <img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*6J6BRIjmXKAAAAAAAAAAAABkARQnAQ" alt="circular layout" width="300">
 
-Arguments
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-38)
 
-- `graph` **Graph**: target graph.
-- `options?` **LayoutOptions**.
-  - `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
-  - `radius` **number** The radius of the circle. If the raidus exists, startRadius and endRadius do not take effect.
-  - `startRadius` **number** The start radius of spiral layout. The default value is `null`.
-  - `endRadius` **number** The end radius of spiral layout. The default value is `null`.
-  - `clockwise` **boolean** Whether to layout clockwisely. The default value is `true`.
-  - `divisions` **number** The division number of the nodes on the circle. Takes effect when `endRadius - startRadius !== 0`. The default value is `1`.
-  - `ordering` **null | 'topology' | 'degree'** The ordering method for nodes. `null` by default, which means the nodes are arranged in data order. `'topology'` means in topology order; `'degree'` means in degree order.
-  - `angleRatio` **number** How many `2*PI`s Between the first node and the last node. The default value is `1`.
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `radius` **number** The radius of the circle. If the raidus exists, startRadius and endRadius do not take effect.
+- `startRadius` **number** The start radius of spiral layout. The default value is `null`.
+- `endRadius` **number** The end radius of spiral layout. The default value is `null`.
+- `clockwise` **boolean** Whether to layout clockwisely. The default value is `true`.
+- `divisions` **number** The division number of the nodes on the circle. Takes effect when `endRadius - startRadius !== 0`. The default value is `1`.
+- `ordering` **null | 'topology' | 'degree'** The ordering method for nodes. `null` by default, which means the nodes are arranged in data order. `'topology'` means in topology order; `'degree'` means in degree order.
+- `angleRatio` **number** How many `2*PI`s Between the first node and the last node. The default value is `1`.
+
+### Random
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*G5_uRodUTaYAAAAAAAAAAABkARQnAQ" alt="random layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-226)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `width` **number** The width of the graph.
+- `height` **number** The height of the graph.
+
+### Grid
+
+Grid orders the nodes according to the configurations and arranged them onto grid.
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*Oh6mRLVEBBIAAAAAAAAAAABkARQnAQ" alt="grid layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-438)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `width` **number** The width of the graph.
+- `height` **number** The height of the graph.
+- `rows` **number** The row number of the grid. If `rows` and `cols` is not provided, the algorithm will calculate it according to the space and node numbers automatically.
+- `cols` **number** The col number of the grid.
+- `condense` **boolean** Wheter to utilize the minimum space of the canvas. `false` means utilizing the full space, `true` means utilizing the minimum space.
+- `preventOverlap` **boolean** Whether to prevent node overlappings. To activate preventing node overlappings, nodeSize is required, which is used for collide detection. The size in the node data will take effect if nodeSize is not assigned. If the size in node data does not exist either, nodeSize is assigned to 30 by default.
+- `nodeSize` **number** The diameter of the node. It is used for preventing node overlappings.
+- `preventOverlapPadding` **boolean** The minimum padding between nodes to prevent node overlappings. Takes effect when preventOverlap is true.
+- `sortBy` **string** The ordering method for nodes. Smaller the index in the ordered array, more center the node will be placed. If sortBy is `undefined`, the algorithm order the nodes according to their degrees.
+
+### MDS
+
+MDS (Multidimensional scaling) is used for project high dimensional data onto low dimensional space.
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*aUS7TJR2NHcAAAAAAAAAAABkARQnAQ" alt="MDS layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-557)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `linkDistance` **number** The edge length. The default value is `50`.
+
+### Concentric
+
+Concentric arranges the nodes on several concentric circles. Each node is sorted by degree by default. The greater the degree of a node, the closer it is to the center point.
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*QpyPTbBpO2AAAAAAAAAAAABkARQnAQ" alt="concentric layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-596)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `width` **number** The width of the graph.
+- `height` **number** The height of the graph.
+- `maxLevelDiff` **number** The sum of concentric values in each level. If it is `undefined`, `maxValue / 4` will take place, where maxValue is the max value of ordering properties. For example, if sortBy is `'degree'`, maxValue is the max degree value of all the nodes.
+- `nodeSize` **number** The diameter of the node. It is used for preventing node overlappings. The default value is `30`.
+- `minNodeSpacing` **number** The minimum separation between adjacent nodes. The default value is `10`.
+- `clockwise` **boolean** Place the nodes in clockwise or not. The default value is `true`.
+- `startAngle` **number** Where nodes start in radians. The default value is `(3 / 2) * Math.PI`.
+- `equidistant` **boolean** Whether levels have an equal radial distance between them, may cause bounding box overflow. The default value is `false`.
+
+### Radial
+
+Radial layout arranges the nodes to concentrics centered at a focus node according to their shortest path length to the focus node. We implements it according to the paper: [More Flexible Radial Layout](http://emis.ams.org/journals/JGAA/accepted/2011/BrandesPich2011.15.1.pdf).
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*GAFjRJeAoAsAAAAAAAAAAABkARQnAQ" alt="radial layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-874)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `width` **number** The width of the graph.
+- `height` **number** The height of the graph.
+- `linkDistance` **number** The edge length. The default value is `50`.
+- `focusNode` **string** The focus node of the radial layout. The first node of the data is the default value. It can be the id of a node or the node item.
+- `unitRadius` **number** The separation between adjacent circles. If not provided, the layout will fill the canvas automatically.
+- `preventOverlap` **boolean** Whether to prevent node overlappings. To activate preventing node overlappings, nodeSize is required, which is used for collide detection. The size in the node data will take effect if nodeSize is not assigned. If the size in node data does not exist either, nodeSize is assigned to 30 by default.
+- `nodeSize` **number** The diameter of the node. It is used for preventing node overlappings.
+- `preventOverlapPadding` **boolean** The minimum padding between nodes to prevent node overlappings. Takes effect when preventOverlap is true.
+- `nodeSpacing` **number** It is the minimum distance between nodes to prevent node overlappings.
+- `strictRadial` **boolean** Whether to layout the graph as strict radial, which means the nodes will be arranged on each circle strictly. Takes effect only when preventOverlap is true.
+  - `true` The overlapped nodes can be arranged around their circle with small offsets.
+  - `false` The overlapped nodes are arranged along their circles strictly. But for the situation that there are too many nodes on a circle to be arranged, the overlappings might not be eliminated completely.
+- `sortBy` **string** Sort the nodes of the same level. undefined by default, which means place the nodes with connections as close as possible; 'data' means place the node according to the ordering in data, the closer the nodes in data ordering, the closer the nodes will be placed. sortBy also can be assigned to any name of property in nodes data, such as 'cluster', 'name' and so on (make sure the property exists in the data)
+- `sortStrength` **number** The strength to sort the nodes in the same circle. Larger number means place the nodes with smaller distance of sortBy more closely. Takes effect only when sortBy is not undefined.
+
+### Fruchterman
+
+Fruchterman is a kind of force-directed layout. The implementation is according to the paper [Graph Drawing by Force-directed Placement](http://www.mathe2.uni-bayreuth.de/axel/papers/reingold:graph_drawing_by_force_directed_placement.pdf).
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*jK3ITYqVJnQAAAAAAAAAAABkARQnAQ" alt="fruchterman layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-1058)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `width` **number** The width of the graph.
+- `height` **number** The height of the graph.
+- `maxIteration` **number**
+- `gravity` **number** The gravity, which will affect the compactness of the layout. The default value is `10`.
+- `speed` **number** The moving speed of each iteraction. Large value of the speed might lead to violent swing.
+- `clustering` **boolean** We can also layout according to `nodeClusterBy` field in data when enable clustering.
+- `clusterGravity` The gravity of each cluster, which will affect the compactness of each cluster. The default value is `10`.
+
+### D3Force
+
+Force is the classical force-dicrected layout algorithm, which corresponds to force-directed layout in d3.js.
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*Nt45Q6nnK2wAAAAAAAAAAABkARQnAQ" alt="d3force layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-791)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`
+- `linkDistance` **number** The edge length. The default length is `50`.
+- `nodeStrength` **number** The strength of node force. Positive value means attractive force, negative value means repulsive force.
+- `edgeStrength` **number** The strength of edge force, ranges from 0 to 1. Calculated according to the degree of nodes by default.
+- `preventOverlap` **boolean**
+- `collideStrength` **number** The strength of force for preventing node overlappings. The range is `[0, 1]`.
+- `nodeSize` **number** The diameter of the node. It is used for preventing node overlappings. If nodeSize is not assigned, the size property in node data will take effect. If the size in node data does not exist either, nodeSize is assigned to `10` by default.
+- `nodeSpacing` **number** The minimum space between two nodes when preventOverlap is true. The default value is `0`.
+
+### Force
+
+Force2 implements the force-directed layout algorithm. It comes from graphin-force, supports assign different masses and center gravities for different nodes freedomly. Comparing to graphin-force, the performance is improved greatly.
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*lX-qSqDECrIAAAAAAAAAAAAAARQnAQ" alt="force layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-1402)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`.
+- `linkDistance` **number** The edge length. The default length is `200`.
+- `nodeStrength` **number** The strength of node force. Positive value means repulsive force, negative value means attractive force (it is different from 'force'). The default value is `1000`.
+- `edgeStrength` **number** The strength of edge force. Calculated according to the degree of nodes by default. The default value is `200`.
+- `preventOverlap` **boolean**
+- `nodeSize` **number** The diameter of the node. It is used for preventing node overlappings. If nodeSize is not assigned, the size property in node data will take effect. If the size in node data does not exist either, nodeSize is assigned to `10` by default.
+- `nodeSpacing` **number** The minimum space between two nodes when preventOverlap is true. The default value is `0`.
+- `minMovement` **number** When the average/minimum/maximum (according to `distanceThresholdMode`) movement of nodes in one iteration is smaller than minMovement, terminate the layout.
+- `distanceThresholdMode` **'mean' | 'max' ｜ 'min'** The condition to judge with minMovement, `'mean'` means the layout stops while the nodes' average movement is smaller than minMovement, `'max' / 'min'` means the layout stops while the nodes' maximum/minimum movement is smaller than minMovement. `'mean'` by default
+- `damping` **number** Range [0, 1], affect the speed of decreasing node moving speed. Large the number, slower the decreasing. The default value is `0.9`.
+- `interval` **number** Controls the speed of the nodes' movement in each iteration. The default value is `0.02`.
+- `maxSpeed` **number** The max speed in each iteration. The default value is `1000`.
+- `force` **number** Coefficient for the repulsive force. Larger the number, larger the repulsive force.
+- `coulombDisScale` **number** A parameter for repulsive force between nodes. Large the number, larger the repulsion. The default value is `0.005`.
+- `gravity` **number** The gravity strength to the center for all the nodes. Larger the number, more compact the nodes. The default value is `10`.
+
+### ForceAtlas2
+
+FA2 is a kind of force directed layout, which performs better on the convergence and compactness.
+
+<img src="https://gw.alipayobjects.com/mdn/rms_f8c6a0/afts/img/A*MqwAQZLIVPwAAAAAAAAAAAAAARQnAQ" alt="forceAtlas2 layout" width="300">
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-1542)
+
+LayoutOptions:
+
+- `center` **[number, number]** The center of the graph. e.g. `[0, 0]`.
+- `kr` **number** Repulsive parameter, smaller the kr, more compact the graph. The default value is `5`.
+- `kg` **number** The parameter for the gravity. Larger kg, the graph will be more compact to the center. The default value is `5`.
+- `ks` **number** The moving speed of the nodes during iterations. The default value is `0.1`.
+- `tao` **number** The threshold of the swinging. The default value is `0.1`.
+- `preventOverlap` **boolean**
+- `dissuadeHubs` **boolean** Wheather to enable hub mode. If it is `true`, the nodes with larger in-degree will be placed on the center in higher priority.
+- `barnesHut` **boolean** Whether to enable the barnes hut speedup, which is the quad-tree optimization. Due to the computation for quad-tree re-build in each iteration, we sugguest to enable it in large graph. It is `undefined` by deafult, when the number of nodes is larger than 250, it will be activated automatically. If it is set to be `false`, it will not be activated anyway.
 
 ### Supervisor
+
+Sometimes we need to execute CPU-intensive algorithms in WebWorker so as not to block the main thread. For this we encapsulate a class called Supervisor. It accepts a graph model and layout algorithm as parameters, completes the creation and communication of WebWorker internally, and notifies the main thread through events after the calculation is completed.
 
 ```js
 const graph = new Graph();
 const layout = new CircularLayout();
 
-const supervisor = new Supervisor(graph, layout, { auto: true });
+const supervisor = new Supervisor(graph, layout);
+supervisor.on("layoutend", (positions) => {});
 supervisor.start();
 ```
+
+[Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-199)
 
 ## License
 

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -1,4 +1,4 @@
-## About
+# @antv/layout
 
 Collection of basic layout algorithms to be used with [@antv/graphlib]().
 

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -21,7 +21,7 @@
     "antv"
   ],
   "dependencies": {
-    "@antv/graphlib": "^2.0.0-alpha.2",
+    "@antv/graphlib": "^2.0.0-alpha.3",
     "@naoak/workerize-transferable": "^0.1.0",
     "d3-force": "^3.0.0",
     "d3-quadtree": "^3.0.1",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout",
-  "version": "1.0.0-alpha.14",
+  "version": "1.0.0-alpha.15",
   "description": "graph layout algorithm",
   "main": "dist/index.min.js",
   "module": "esm/index.esm.js",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "graph layout algorithm",
   "main": "dist/index.min.js",
   "module": "esm/index.esm.js",
@@ -22,11 +22,13 @@
   ],
   "dependencies": {
     "@antv/graphlib": "^2.0.0-alpha.3",
+    "@antv/util": "^3.0.0",
     "@naoak/workerize-transferable": "^0.1.0",
     "d3-force": "^3.0.0",
     "d3-quadtree": "^3.0.1",
     "eventemitter3": "^4.0.0",
-    "ml-matrix": "^6.10.4"
+    "ml-matrix": "^6.10.4",
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/packages/layout/src/circular.ts
+++ b/packages/layout/src/circular.ts
@@ -11,8 +11,6 @@ import type {
 import { formatSizeFn, formatNumberFn, cloneFormatData } from "./util";
 import { handleSingleNodeGraph } from "./util/common";
 
-// TODO: graph getDegree, getNeighbors, getSuccessors considering the hidden nodes according to layoutInvisible
-
 const DEFAULTS_LAYOUT_OPTIONS: Partial<CircularLayoutOptions> = {
   radius: null,
   startRadius: null,
@@ -84,24 +82,11 @@ export class CircularLayout implements Layout<CircularLayoutOptions> {
       clockwise,
       nodeSpacing: paramNodeSpacing,
       nodeSize: paramNodeSize,
-      layoutInvisibles,
       onLayoutEnd,
     } = mergedOptions;
 
     let nodes: Node[] = graph.getAllNodes();
     let edges: Edge[] = graph.getAllEdges();
-
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
 
     // Calculate center according to `window` if not provided.
     const [calculatedWidth, calculatedHeight, calculatedCenter] =

--- a/packages/layout/src/concentric.ts
+++ b/packages/layout/src/concentric.ts
@@ -83,24 +83,11 @@ export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
       startAngle = (3 / 2) * Math.PI,
       nodeSize,
       nodeSpacing,
-      layoutInvisibles,
       onLayoutEnd,
     } = mergedOptions;
 
     let nodes = graph.getAllNodes();
     let edges = graph.getAllEdges();
-
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
 
     const width =
       !propsWidth && typeof window !== "undefined"

--- a/packages/layout/src/concentric.ts
+++ b/packages/layout/src/concentric.ts
@@ -1,3 +1,4 @@
+import { isFunction, isNumber, isObject, isString } from "@antv/util";
 import type {
   Graph,
   Node,
@@ -8,14 +9,7 @@ import type {
   Layout,
   IndexMap,
 } from "./types";
-import {
-  cloneFormatData,
-  isArray,
-  isFunction,
-  isNumber,
-  isObject,
-  isString,
-} from "./util";
+import { cloneFormatData, isArray } from "./util";
 import { handleSingleNodeGraph } from "./util/common";
 
 const DEFAULTS_LAYOUT_OPTIONS: Partial<ConcentricLayoutOptions> = {
@@ -116,9 +110,9 @@ export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
       !propsHeight && typeof window !== "undefined"
         ? window.innerHeight
         : (propsHeight as number);
-    const center = (!propsCenter
-      ? [width / 2, height / 2]
-      : propsCenter) as PointTuple;
+    const center = (
+      !propsCenter ? [width / 2, height / 2] : propsCenter
+    ) as PointTuple;
 
     if (!nodes?.length || nodes.length === 1) {
       return handleSingleNodeGraph(graph, assign, center, onLayoutEnd);

--- a/packages/layout/src/d3Force/index.ts
+++ b/packages/layout/src/d3Force/index.ts
@@ -1,4 +1,5 @@
 import * as d3Force from "d3-force";
+import { isFunction, isNumber, isObject } from "@antv/util";
 import {
   Graph,
   Node,
@@ -8,13 +9,7 @@ import {
   Edge,
   LayoutWithIterations,
 } from "../types";
-import {
-  cloneFormatData,
-  isArray,
-  isFunction,
-  isNumber,
-  isObject,
-} from "../util";
+import { cloneFormatData, isArray } from "../util";
 import forceInBox from "./forceInBox";
 
 /**

--- a/packages/layout/src/d3Force/index.ts
+++ b/packages/layout/src/d3Force/index.ts
@@ -139,20 +139,9 @@ export class D3ForceLayout
     options?: D3ForceLayoutOptions
   ): LayoutMapping | void {
     const mergedOptions = { ...this.options, ...options };
-    const { layoutInvisibles } = mergedOptions;
 
     let nodes = graph.getAllNodes();
     let edges = graph.getAllEdges();
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
     const layoutNodes: CalcNode[] = nodes.map(
       (node) =>
         ({

--- a/packages/layout/src/force/index.ts
+++ b/packages/layout/src/force/index.ts
@@ -1,4 +1,5 @@
 import { Graph as IGraph } from "@antv/graphlib";
+import { isNumber, isObject } from "@antv/util";
 import {
   Graph,
   Node,
@@ -9,7 +10,7 @@ import {
   OutNode,
   LayoutWithIterations,
 } from "../types";
-import { formatNumberFn, isArray, isNumber, isObject } from "../util";
+import { formatNumberFn, isArray } from "../util";
 import { forceNBody } from "./forceNBody";
 import {
   CalcNode,
@@ -339,7 +340,7 @@ export class ForceLayout implements LayoutWithIterations<ForceLayoutOptions> {
             if (isArray(size)) {
               return Math.max(size[0], size[1]) + nodeSpacingFunc(d);
             }
-            if (isObject(size)) {
+            if (isObject<{ width: number; height: number }>(size)) {
               return Math.max(size.width, size.height) + nodeSpacingFunc(d);
             }
             return (size as number) + nodeSpacingFunc(d);

--- a/packages/layout/src/force/index.ts
+++ b/packages/layout/src/force/index.ts
@@ -173,14 +173,6 @@ export class ForceLayout implements LayoutWithIterations<ForceLayoutOptions> {
 
     let nodes = graph.getAllNodes();
     let edges = graph.getAllEdges();
-    if (!mergedOptions.layoutInvisibles) {
-      nodes = nodes.filter(
-        (node) => node.data.visible || node.data.visible === undefined
-      );
-      edges = edges.filter(
-        (edge) => edge.data.visible || edge.data.visible === undefined
-      );
-    }
 
     const formattedOptions = this.formatOptions(mergedOptions, graph);
     const {
@@ -631,8 +623,8 @@ export class ForceLayout implements LayoutWithIterations<ForceLayoutOptions> {
   ) {
     const { getCenter } = options;
     const calcNodes = calcGraph.getAllNodes();
-    const nodes = graph.getAllNodes(); // TODO: filter out the invisibles
-    const edges = graph.getAllEdges(); // TODO: filter out the invisibles
+    const nodes = graph.getAllNodes();
+    const edges = graph.getAllEdges();
     const {
       width,
       height,

--- a/packages/layout/src/forceAtlas2/index.ts
+++ b/packages/layout/src/forceAtlas2/index.ts
@@ -1,3 +1,4 @@
+import { isFunction, isNumber, isObject } from "@antv/util";
 import { Graph as GGraph } from "@antv/graphlib";
 import type {
   Graph,
@@ -11,13 +12,7 @@ import type {
   EdgeData,
   LayoutWithIterations,
 } from "../types";
-import {
-  cloneFormatData,
-  isArray,
-  isFunction,
-  isNumber,
-  isObject,
-} from "../util";
+import { cloneFormatData, isArray } from "../util";
 import { handleSingleNodeGraph } from "../util/common";
 import Body from "./body";
 import Quad from "./quad";

--- a/packages/layout/src/fruchterman.ts
+++ b/packages/layout/src/fruchterman.ts
@@ -1,3 +1,4 @@
+import { isNumber } from "@antv/util";
 import { Graph as IGraph } from "@antv/graphlib";
 import type {
   Graph,
@@ -11,7 +12,7 @@ import type {
   Point,
   LayoutWithIterations,
 } from "./types";
-import { cloneFormatData, isNumber } from "./util";
+import { cloneFormatData } from "./util";
 
 const DEFAULTS_LAYOUT_OPTIONS: Partial<FruchtermanLayoutOptions> = {
   maxIteration: 1000,

--- a/packages/layout/src/fruchterman.ts
+++ b/packages/layout/src/fruchterman.ts
@@ -166,7 +166,6 @@ export class FruchtermanLayout
 
     const formattedOptions = this.formatOptions(options);
     const {
-      layoutInvisibles,
       width,
       height,
       center,
@@ -179,17 +178,6 @@ export class FruchtermanLayout
 
     let nodes = graph.getAllNodes();
     let edges = graph.getAllEdges();
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
 
     if (!nodes?.length) {
       const result = { nodes: [], edges };

--- a/packages/layout/src/grid.ts
+++ b/packages/layout/src/grid.ts
@@ -99,7 +99,6 @@ export class GridLayout implements Layout<GridLayoutOptions> {
       nodeSize: paramNodeSize,
       width: propsWidth,
       height: propsHeight,
-      layoutInvisibles,
       onLayoutEnd,
       position,
     } = mergedOptions;
@@ -107,18 +106,6 @@ export class GridLayout implements Layout<GridLayoutOptions> {
 
     let nodes: Node[] = graph.getAllNodes();
     let edges: Edge[] = graph.getAllEdges();
-
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
 
     const n = nodes?.length;
 

--- a/packages/layout/src/grid.ts
+++ b/packages/layout/src/grid.ts
@@ -1,11 +1,5 @@
-import {
-  isString,
-  isArray,
-  isNumber,
-  formatSizeFn,
-  formatNumberFn,
-  cloneFormatData,
-} from "./util";
+import { isString, isNumber } from "@antv/util";
+import { isArray, formatSizeFn, formatNumberFn, cloneFormatData } from "./util";
 import type {
   Graph,
   GridLayoutOptions,

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -9,4 +9,6 @@ export * from "./radial";
 export * from "./fruchterman";
 export * from "./d3Force";
 export * from "./force";
-export * from './forceAtlas2';
+export * from "./forceAtlas2";
+export * from "./types";
+export * from "./util";

--- a/packages/layout/src/mds.ts
+++ b/packages/layout/src/mds.ts
@@ -65,27 +65,10 @@ export class MDSLayout implements Layout<MDSLayoutOptions> {
     options?: MDSLayoutOptions
   ): LayoutMapping | void {
     const mergedOptions = { ...this.options, ...options };
-    const {
-      center = [0, 0],
-      linkDistance = 50,
-      layoutInvisibles,
-      onLayoutEnd,
-    } = mergedOptions;
+    const { center = [0, 0], linkDistance = 50, onLayoutEnd } = mergedOptions;
 
     let nodes = graph.getAllNodes();
     let edges = graph.getAllEdges();
-
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
 
     if (!nodes?.length || nodes.length === 1) {
       return handleSingleNodeGraph(graph, assign, center, onLayoutEnd);

--- a/packages/layout/src/radial/index.ts
+++ b/packages/layout/src/radial/index.ts
@@ -1,3 +1,4 @@
+import { isString, isFunction, isNumber, isObject } from "@antv/util";
 import type {
   Graph,
   Node,
@@ -15,10 +16,6 @@ import {
   getAdjMatrix,
   getEuclideanDistance,
   isArray,
-  isFunction,
-  isNumber,
-  isObject,
-  isString,
 } from "../util";
 import { handleSingleNodeGraph } from "../util/common";
 import { mds } from "./mds";
@@ -503,14 +500,13 @@ const formatNodeSize = (
         if (isArray(d.data.size)) {
           return Math.max(d.data.size[0], d.data.size[1]) + nodeSpacingFunc(d);
         }
-        if (isObject(d.data.size)) {
+        const dataSize = d.data.size;
+        if (isObject<{ width: number; height: number }>(dataSize)) {
           const res =
-            d.data.size.width > d.data.size.height
-              ? d.data.size.width
-              : d.data.size.height;
+            dataSize.width > dataSize.height ? dataSize.width : dataSize.height;
           return res + nodeSpacingFunc(d);
         }
-        return d.data.size + nodeSpacingFunc(d);
+        return dataSize + nodeSpacingFunc(d);
       }
       return 10 + nodeSpacingFunc(d);
     };

--- a/packages/layout/src/radial/index.ts
+++ b/packages/layout/src/radial/index.ts
@@ -94,24 +94,11 @@ export class RadialLayout implements Layout<RadialLayoutOptions> {
       linkDistance = 50,
       sortStrength = 10,
       maxIteration = 1000,
-      layoutInvisibles,
       onLayoutEnd,
     } = mergedOptions;
 
     let nodes = graph.getAllNodes();
     let edges = graph.getAllEdges();
-
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-      edges = edges.filter((edge) => {
-        const { visible } = edge.data || {};
-        return visible || visible === undefined;
-      });
-    }
 
     const width =
       !propsWidth && typeof window !== "undefined"

--- a/packages/layout/src/random.ts
+++ b/packages/layout/src/random.ts
@@ -61,18 +61,10 @@ export class RandomLayout implements Layout<RandomLayoutOptions> {
       center: propsCenter,
       width: propsWidth,
       height: propsHeight,
-      layoutInvisibles,
       onLayoutEnd,
     } = mergedOptions;
 
     let nodes = graph.getAllNodes();
-    // TODO: use graphlib's view with filter after graphlib supports it
-    if (!layoutInvisibles) {
-      nodes = nodes.filter((node) => {
-        const { visible } = node.data || {};
-        return visible || visible === undefined;
-      });
-    }
     const layoutScale = 0.9;
     const width =
       !propsWidth && typeof window !== "undefined"

--- a/packages/layout/src/types.ts
+++ b/packages/layout/src/types.ts
@@ -3,6 +3,7 @@ import {
   Node as INode,
   Edge as IEdge,
   PlainObject,
+  GraphView as IGraphView,
 } from "@antv/graphlib";
 
 export interface NodeData extends PlainObject {
@@ -41,6 +42,7 @@ export type IndexMap = {
 };
 
 export type Graph = IGraph<NodeData, EdgeData>;
+export type GraphView = IGraphView<NodeData, EdgeData>;
 
 export type PointTuple = [number, number];
 export type Point = { x: number; y: number };

--- a/packages/layout/src/types.ts
+++ b/packages/layout/src/types.ts
@@ -109,8 +109,6 @@ export interface LayoutSupervisor {
 
 // most layout options extends CommonOptions
 interface CommonOptions {
-  // whether take the invisible nodes and edges into calculation, false by default
-  layoutInvisibles?: boolean;
   onLayoutEnd?: (data: LayoutMapping) => void;
 }
 

--- a/packages/layout/src/util/function.ts
+++ b/packages/layout/src/util/function.ts
@@ -1,9 +1,6 @@
+import { isFunction, isNumber, isObject } from "@antv/util";
 import { Node } from "../types";
-import { isArray, isObject } from ".";
-import { isNumber } from "./number";
-
-export const isFunction = (val: unknown): val is Function =>
-  typeof val === "function";
+import { isArray } from ".";
 
 /**
  * Format value with multiple types into a function returns number.
@@ -52,7 +49,7 @@ export function formatSizeFn<T extends Node>(
         if (isArray(size)) {
           return size[0] > size[1] ? size[0] : size[1];
         }
-        if (isObject(size)) {
+        if (isObject<{ width: number; height: number }>(size)) {
           return size.width > size.height ? size.width : size.height;
         }
         return size;

--- a/packages/layout/src/util/math.ts
+++ b/packages/layout/src/util/math.ts
@@ -1,13 +1,6 @@
-import type {
-  Matrix,
-  Edge,
-  Node,
-  OutNode,
-  Degree,
-  Point,
-} from "../types";
+import { isNumber } from "@antv/util";
+import type { Matrix, Edge, Node, OutNode, Degree, Point } from "../types";
 import { isArray } from "./array";
-import { isNumber } from "./number";
 
 export const floydWarshall = (adjMatrix: Matrix[]): Matrix[] => {
   // initialize
@@ -38,7 +31,10 @@ export const floydWarshall = (adjMatrix: Matrix[]): Matrix[] => {
   return dist;
 };
 
-export const getAdjMatrix = (data: { nodes: Node[]; edges: Edge[] }, directed: boolean): Matrix[] => {
+export const getAdjMatrix = (
+  data: { nodes: Node[]; edges: Edge[] },
+  directed: boolean
+): Matrix[] => {
   const { nodes, edges } = data;
   const matrix: Matrix[] = [];
   // map node with index in data.nodes
@@ -228,7 +224,9 @@ const getSameTypeNodes = (
 ) => {
   const typeName = node[nodeClusterBy as keyof Node] || "";
   let sameTypeNodes =
-    relativeNodes?.filter((item) => item[nodeClusterBy as keyof Node] === typeName) || [];
+    relativeNodes?.filter(
+      (item) => item[nodeClusterBy as keyof Node] === typeName
+    ) || [];
   if (type === "leaf") {
     sameTypeNodes = sameTypeNodes.filter(
       (node) => degreesMap[node.id]?.in === 0 || degreesMap[node.id]?.out === 0
@@ -279,10 +277,9 @@ export const getCoreNodeAndRelativeLeafNodes = (
 
 /**
  * calculate the euclidean distance form p1 to p2
- * @param p1 
- * @param p2 
- * @returns 
+ * @param p1
+ * @param p2
+ * @returns
  */
-export const getEuclideanDistance = (p1: Point, p2: Point) => Math.sqrt(
-  (p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y)
-);
+export const getEuclideanDistance = (p1: Point, p2: Point) =>
+  Math.sqrt((p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y));

--- a/packages/layout/src/util/number.ts
+++ b/packages/layout/src/util/number.ts
@@ -1,8 +1,3 @@
-export const isNumber = (val: unknown): val is Number =>
-  typeof val === "number";
-
-export const isNaN = (num: unknown) => Number.isNaN(Number(num));
-
 export const toNumber = (val: any): any => {
   const n = parseFloat(val);
   return isNaN(n) ? val : n;

--- a/packages/layout/src/util/object.ts
+++ b/packages/layout/src/util/object.ts
@@ -1,8 +1,5 @@
+import { isNumber } from "@antv/util";
 import { Node, Edge } from "../types";
-import { isNumber } from "./number";
-
-export const isObject = (val: unknown): val is Record<any, any> =>
-  val !== null && typeof val === "object";
 
 export const clone = <T>(target: T): T => {
   if (target === null) {

--- a/packages/layout/src/util/string.ts
+++ b/packages/layout/src/util/string.ts
@@ -1,6 +1,3 @@
-export const isString = (val: unknown): val is string =>
-  typeof val === "string";
-
 const cacheStringFunction = <T extends (str: string) => string>(fn: T): T => {
   const cache: Record<string, string> = Object.create(null);
   return ((str: string) => {


### PR DESCRIPTION
文档
- 增加 monorep 的 README.md 以及各个子包的文档
  - 其中 `@antv/layout` 的 API 文档在 [README.md ](https://github.com/antvis/layout/pull/135/files#diff-9cdff10c81c28f982ab2a497cd6883391d2d8a9af53f6d294ad593c7ae297cb6)中

@antv/layout
- 移除 layout visible 相关逻辑，后续使用 GraphView 实现过滤
- 使用 `@antv/util` 中的 `isString` `isNumber` `isFunction` `isObject` 等工具方法

@antv/layout-gpu
- 发布 `@antv/layout-gpu` https://www.npmjs.com/package/@antv/layout-gpu
- 构建时将 `@antv/layout` external，但目前需要指明 alpha dist-tag，否则在 OB 上无法解析依赖。正式版后需要修改：
```js
// webpack.config.js
externals: {
  "@antv/layout": {
    commonjs: "@antv/layout@alpha",
    commonjs2: "@antv/layout@alpha",
    amd: "@antv/layout@alpha",
    root: "Layout", // indicates global variable
  },
},
```