### PR TITLE
统一 execute & assign 到异步方式

### DIFF
--- a/__tests__/unit/circular.test.ts
+++ b/__tests__/unit/circular.test.ts
@@ -1,23 +1,23 @@
 import { Graph } from "@antv/graphlib";
-import { CircularLayout } from "@antv/layout";
+import { CircularLayout, NodeData, EdgeData } from "@antv/layout";
 import dataset from "../data";
 import { mathEqual } from "../util";
 const data = dataset.data;
 
 describe("CircularLayout", () => {
-  it("should skip layout when there's no node in graph.", () => {
-    const graph = new Graph<any, any>({
+  it("should skip layout when there's no node in graph.", async () => {
+    const graph = new Graph<NodeData, EdgeData>({
       nodes: [],
       edges: [],
     });
 
     const circular = new CircularLayout();
 
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
     expect(positions).toEqual({ nodes: [], edges: [] });
 
     // Graph should remain unchanged.
-    circular.assign(graph);
+    await circular.assign(graph);
     expect(graph.getAllNodes()).toEqual([]);
     expect(graph.getAllEdges()).toEqual([]);
 
@@ -26,8 +26,8 @@ describe("CircularLayout", () => {
     // expect(mockOnLayoutEnd).toHaveBeenCalledTimes(1);
   });
 
-  it("should layout quickly when there's only one node in graph.", () => {
-    const graph = new Graph<any, any>({
+  it("should layout quickly when there's only one node in graph.", async () => {
+    const graph = new Graph<NodeData, EdgeData>({
       nodes: [{ id: "Node1", data: {} }],
       edges: [],
     });
@@ -35,7 +35,7 @@ describe("CircularLayout", () => {
     const circular = new CircularLayout();
 
     // Use user-defined center.
-    const positions = circular.execute(graph, { center: [100, 100] });
+    const positions = await circular.execute(graph, { center: [100, 100] });
     expect(positions).toEqual({
       nodes: [
         {
@@ -49,7 +49,7 @@ describe("CircularLayout", () => {
       edges: [],
     });
 
-    circular.assign(graph, { center: [100, 100] });
+    await circular.assign(graph, { center: [100, 100] });
     expect(graph.getAllNodes()).toEqual([
       {
         id: "Node1",
@@ -62,8 +62,8 @@ describe("CircularLayout", () => {
     expect(graph.getAllEdges()).toEqual([]);
   });
 
-  it("should layout with fixed radius, start angle, end angle.", () => {
-    const graph = new Graph<any, any>({
+  it("should layout with fixed radius, start angle, end angle.", async () => {
+    const graph = new Graph<NodeData, EdgeData>({
       // @ts-ignore
       nodes: data.nodes,
       // @ts-ignore
@@ -77,7 +77,7 @@ describe("CircularLayout", () => {
       endAngle: Math.PI,
     });
 
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
 
     const pos = (200 * Math.sqrt(2)) / 2;
 
@@ -85,7 +85,7 @@ describe("CircularLayout", () => {
     expect(mathEqual(positions.nodes[0].data.y, 250 + pos)).toEqual(true);
   });
 
-  it("circular with no radius but startRadius and endRadius", () => {
+  it("circular with no radius but startRadius and endRadius", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -97,7 +97,7 @@ describe("CircularLayout", () => {
       startRadius: 1,
       endRadius: 100,
     });
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
 
     expect(positions.nodes[0].data.x).toEqual(150 + 1);
     expect(positions.nodes[0].data.y).toEqual(200);
@@ -107,7 +107,7 @@ describe("CircularLayout", () => {
     expect(mathEqual(nodeModelLast.data.y, 180)).toEqual(true);
   });
 
-  it("circular with no radius and startRadius but endRadius", () => {
+  it("circular with no radius and startRadius but endRadius", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -118,13 +118,13 @@ describe("CircularLayout", () => {
       center: [150, 200],
       endRadius: 100,
     });
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
     const nodeModelFirst = positions.nodes[0];
     expect(nodeModelFirst.data.x).toEqual(150 + 100);
     expect(nodeModelFirst.data.y).toEqual(200);
   });
 
-  it("circular with no radius and endRadius but startRadius", () => {
+  it("circular with no radius and endRadius but startRadius", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -135,13 +135,13 @@ describe("CircularLayout", () => {
       center: [150, 200],
       startRadius: 100,
     });
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
     const nodeModelFirst = positions.nodes[0];
     expect(nodeModelFirst.data.x).toEqual(150 + 100);
     expect(nodeModelFirst.data.y).toEqual(200);
   });
 
-  it("circular with topology ordering", () => {
+  it("circular with topology ordering", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -153,7 +153,7 @@ describe("CircularLayout", () => {
       ordering: "topology",
       radius: 200,
     });
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
 
     let node0, node1, node2, node3;
     positions.nodes.forEach((node) => {
@@ -179,7 +179,7 @@ describe("CircularLayout", () => {
     expect(mathEqual(dist3, dist2)).toEqual(true);
   });
 
-  it("circular with topology-directed ordering", () => {
+  it("circular with topology-directed ordering", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -191,7 +191,7 @@ describe("CircularLayout", () => {
       ordering: "topology-directed",
       radius: 200,
     });
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
 
     let node0, node1, node2, node3;
     positions.nodes.forEach((node) => {
@@ -217,7 +217,7 @@ describe("CircularLayout", () => {
     expect(mathEqual(dist3, dist2)).toEqual(true);
   });
 
-  it("circular with degree ordering, counterclockwise", () => {
+  it("circular with degree ordering, counterclockwise", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -230,7 +230,7 @@ describe("CircularLayout", () => {
       radius: 200,
       clockwise: false,
     });
-    const positions = circular.execute(graph);
+    const positions = await circular.execute(graph);
 
     let node0, node1, node2, node3;
     positions.nodes.forEach((node) => {

--- a/__tests__/unit/concentric.test.ts
+++ b/__tests__/unit/concentric.test.ts
@@ -5,7 +5,7 @@ import { mathEqual } from "../util";
 const data = dataset.data;
 
 describe("ConcentricLayout", () => {
-  it("should return correct default config.", () => {
+  it("should return correct default config.", async () => {
     const concentric = new ConcentricLayout();
     expect(concentric.options).toEqual({
       nodeSize: 30,
@@ -20,17 +20,17 @@ describe("ConcentricLayout", () => {
     });
   });
 
-  it("should do concentric with an empty graph.", () => {
+  it("should do concentric with an empty graph.", async () => {
     const graph = new Graph<any, any>({
       nodes: [],
       edges: [],
     });
     const concentric = new ConcentricLayout();
-    const positions = concentric.execute(graph);
+    const positions = await concentric.execute(graph);
     expect(positions.nodes).toEqual([]);
   });
 
-  it("should do concentric with a graph which has only one node.", () => {
+  it("should do concentric with a graph which has only one node.", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         {
@@ -46,12 +46,12 @@ describe("ConcentricLayout", () => {
     const concentric = new ConcentricLayout({
       center: [150, 50],
     });
-    const positions = concentric.execute(graph);
+    const positions = await concentric.execute(graph);
     expect(positions.nodes[0].data.x).toEqual(150);
     expect(positions.nodes[0].data.y).toEqual(50);
   });
 
-  it("should do concentric with array nodeSize", () => {
+  it("should do concentric with array nodeSize", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -67,13 +67,13 @@ describe("ConcentricLayout", () => {
       height,
     });
 
-    const positions = concentric.execute(graph);
+    const positions = await concentric.execute(graph);
     const node = positions.nodes[2];
     expect(mathEqual(node.data.x, width / 2)).toEqual(true);
     expect(mathEqual(node.data.y, height / 2)).toEqual(true);
   });
 
-  it("should do concentric layout with array size in node data, sortBy in data undefined", () => {
+  it("should do concentric layout with array size in node data, sortBy in data undefined", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -88,13 +88,13 @@ describe("ConcentricLayout", () => {
       width,
       height,
     });
-    const positions = concentric.execute(graph);
+    const positions = await concentric.execute(graph);
     const node = positions.nodes[2];
     expect(mathEqual(node.data.x, width / 2)).toEqual(true);
     expect(mathEqual(node.data.y, height / 2)).toEqual(true);
   });
 
-  it("should use concentric equidistant.", () => {
+  it("should use concentric equidistant.", async () => {
     const graph = new Graph<any, any>({
       // @ts-ignore
       nodes: data.nodes,
@@ -109,7 +109,7 @@ describe("ConcentricLayout", () => {
       height,
       equidistant: true,
     });
-    const positions = concentric.execute(graph);
+    const positions = await concentric.execute(graph);
     const node = positions.nodes[2];
     expect(mathEqual(node.data.x, width / 2)).toEqual(true);
     expect(mathEqual(node.data.y, height / 2)).toEqual(true);

--- a/__tests__/unit/d3Force.test.ts
+++ b/__tests__/unit/d3Force.test.ts
@@ -1,0 +1,52 @@
+import { Graph } from "@antv/graphlib";
+import { D3ForceLayout } from "@antv/layout";
+import data from "../data/test-data-1";
+
+describe("D3ForceLayout", () => {
+  it("should return correct default config.", async () => {
+    const graph = new Graph<any, any>({
+      nodes: [...data.nodes],
+      edges: [...data.edges],
+    });
+
+    const force = new D3ForceLayout({
+      alphaDecay: 0.2,
+      nodeSize: 10,
+    });
+
+    const { nodes } = await force.execute(graph);
+    const node = nodes[0];
+    expect(node.data.x).not.toEqual(undefined);
+    expect(node.data.y).not.toEqual(undefined);
+  });
+
+  it("force layout with onTick", async () => {
+    const graph = new Graph<any, any>({
+      nodes: [...data.nodes],
+      edges: [...data.edges],
+    });
+
+    let x: number;
+    let y: number;
+    let count = 0;
+    let isEnd = false;
+
+    const force = new D3ForceLayout({
+      alphaDecay: 0.2,
+      nodeSize: 10,
+      onTick: ({ nodes }) => {
+        const node = nodes[0];
+        count++;
+        expect(node.data.x !== x);
+        expect(node.data.y !== y);
+        x = node.data.x;
+        y = node.data.y;
+      },
+    });
+
+    const { nodes } = await force.execute(graph);
+    const node = nodes[0];
+    expect(node.data.x).not.toEqual(undefined);
+    expect(node.data.y).not.toEqual(undefined);
+  });
+});

--- a/__tests__/unit/forceAtlas2.test.ts
+++ b/__tests__/unit/forceAtlas2.test.ts
@@ -1,11 +1,10 @@
 import { Graph } from "@antv/graphlib";
 import { ForceAtlas2Layout } from "@antv/layout";
-import data from '../data/test-data-1';
-import { getEuclideanDistance } from '../util';
-
+import data from "../data/test-data-1";
+import { getEuclideanDistance } from "../util";
 
 describe("ForceAtlas2Layout", () => {
-  it("should return correct default config.", () => {
+  it("should return correct default config.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -18,7 +17,7 @@ describe("ForceAtlas2Layout", () => {
       height: 300,
       kr: 5,
       kg: 1,
-      mode: 'normal',
+      mode: "normal",
       preventOverlap: false,
       dissuadeHubs: false,
       maxIteration: 0,
@@ -27,54 +26,54 @@ describe("ForceAtlas2Layout", () => {
       tao: 0.1,
     });
 
-    const positions = fa2.execute(graph);
+    const positions = await fa2.execute(graph);
 
     expect(positions.nodes[0].data.x).not.toBe(undefined);
     expect(positions.nodes[0].data.y).not.toBe(undefined);
   });
 
-  it("should do fa2 layout with an empty graph.", () => {
+  it("should do fa2 layout with an empty graph.", async () => {
     const graph = new Graph<any, any>({
       nodes: [],
       edges: [],
     });
 
     const fa2 = new ForceAtlas2Layout();
-    const positions = fa2.execute(graph);
+    const positions = await fa2.execute(graph);
     expect(positions.nodes).not.toBe(undefined);
   });
 
-  it("should do fa2 layout with a graph which has only one node.", () => {
+  it("should do fa2 layout with a graph which has only one node.", async () => {
     const graph = new Graph<any, any>({
       nodes: [{ id: "node", data: {} }],
       edges: [],
     });
 
     const fa2 = new ForceAtlas2Layout({ center: [10, 20] });
-    const positions = fa2.execute(graph);
+    const positions = await fa2.execute(graph);
 
     expect(positions.nodes[0].data.x).toBe(10);
     expect(positions.nodes[0].data.y).toBe(20);
   });
 
-  it("should do fa2 layout with diffrent kr", () => {
+  it("should do fa2 layout with diffrent kr", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         {
-          id: 'node0',
-          data: {}
+          id: "node0",
+          data: {},
         },
         {
-          id: 'node1',
-          data: {}
+          id: "node1",
+          data: {},
         },
       ],
       edges: [
         {
-          id: 'edge1',
-          source: 'node0',
-          target: 'node1',
-          data: {}
+          id: "edge1",
+          source: "node0",
+          target: "node1",
+          data: {},
         },
       ],
     });
@@ -82,33 +81,39 @@ describe("ForceAtlas2Layout", () => {
     // smaller the kr, more compact the result
 
     const fa21 = new ForceAtlas2Layout({ center: [100, 200], kr: 2 });
-    const positions1 = fa21.execute(graph);
-    const dist1 = getEuclideanDistance(positions1.nodes[0], positions1.nodes[1]);
+    const positions1 = await fa21.execute(graph);
+    const dist1 = getEuclideanDistance(
+      positions1.nodes[0],
+      positions1.nodes[1]
+    );
 
     const fa22 = new ForceAtlas2Layout({ center: [100, 200], kr: 20 });
-    const positions2 = fa22.execute(graph);
-    const dist2 = getEuclideanDistance(positions2.nodes[0], positions2.nodes[1]);
+    const positions2 = await fa22.execute(graph);
+    const dist2 = getEuclideanDistance(
+      positions2.nodes[0],
+      positions2.nodes[1]
+    );
 
     expect(dist1 < dist2).toBe(true);
   });
-  it("should do fa2 layout with diffrent kg", () => {
+  it("should do fa2 layout with diffrent kg", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         {
-          id: 'node0',
-          data: {}
+          id: "node0",
+          data: {},
         },
         {
-          id: 'node1',
-          data: {}
+          id: "node1",
+          data: {},
         },
       ],
       edges: [
         {
-          id: 'edge1',
-          source: 'node0',
-          target: 'node1',
-          data: {}
+          id: "edge1",
+          source: "node0",
+          target: "node1",
+          data: {},
         },
       ],
     });
@@ -116,67 +121,79 @@ describe("ForceAtlas2Layout", () => {
     // larger the kg, more compact the result
 
     const fa21 = new ForceAtlas2Layout({ center: [100, 200], kg: 2 });
-    const positions1 = fa21.execute(graph);
-    const dist1 = getEuclideanDistance(positions1.nodes[0], positions1.nodes[1]);
+    const positions1 = await fa21.execute(graph);
+    const dist1 = getEuclideanDistance(
+      positions1.nodes[0],
+      positions1.nodes[1]
+    );
 
     const fa22 = new ForceAtlas2Layout({ center: [100, 200], kg: 20 });
-    const positions2 = fa22.execute(graph);
-    const dist2 = getEuclideanDistance(positions2.nodes[0], positions2.nodes[1]);
+    const positions2 = await fa22.execute(graph);
+    const dist2 = getEuclideanDistance(
+      positions2.nodes[0],
+      positions2.nodes[1]
+    );
 
     expect(dist1 > dist2).toBe(true);
   });
-  it("should do fa2 layout with diffrent mode", () => {
+  it("should do fa2 layout with diffrent mode", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         {
-          id: 'node0',
-          data: {}
+          id: "node0",
+          data: {},
         },
         {
-          id: 'node1',
-          data: {}
+          id: "node1",
+          data: {},
         },
       ],
       edges: [
         {
-          id: 'edge1',
-          source: 'node0',
-          target: 'node1',
-          data: {}
+          id: "edge1",
+          source: "node0",
+          target: "node1",
+          data: {},
         },
       ],
     });
 
     // normal mode is more compact than linlog mode
 
-    const fa21 = new ForceAtlas2Layout({ center: [100, 200], mode: 'normal' });
-    const positions1 = fa21.execute(graph);
-    const dist1 = getEuclideanDistance(positions1.nodes[0], positions1.nodes[1]);
+    const fa21 = new ForceAtlas2Layout({ center: [100, 200], mode: "normal" });
+    const positions1 = await fa21.execute(graph);
+    const dist1 = getEuclideanDistance(
+      positions1.nodes[0],
+      positions1.nodes[1]
+    );
 
-    const fa22 = new ForceAtlas2Layout({ center: [100, 200], mode: 'linlog' });
-    const positions2 = fa22.execute(graph);
-    const dist2 = getEuclideanDistance(positions2.nodes[0], positions2.nodes[1]);
+    const fa22 = new ForceAtlas2Layout({ center: [100, 200], mode: "linlog" });
+    const positions2 = await fa22.execute(graph);
+    const dist2 = getEuclideanDistance(
+      positions2.nodes[0],
+      positions2.nodes[1]
+    );
 
     expect(dist1 < dist2).toBe(true);
   });
-  it("should do fa2 layout with onTick and onLayoutEnd", (done) => {
+  it("should do fa2 layout with onTick", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         {
-          id: 'node0',
-          data: {}
+          id: "node0",
+          data: {},
         },
         {
-          id: 'node1',
-          data: {}
+          id: "node1",
+          data: {},
         },
       ],
       edges: [
         {
-          id: 'edge1',
-          source: 'node0',
-          target: 'node1',
-          data: {}
+          id: "edge1",
+          source: "node0",
+          target: "node1",
+          data: {},
         },
       ],
     });
@@ -184,41 +201,36 @@ describe("ForceAtlas2Layout", () => {
     let tickCount = 0;
     const fa2 = new ForceAtlas2Layout({
       center: [100, 200],
-      onTick: res => {
+      onTick: (res) => {
         tickCount++;
         expect(res.nodes[0].data.x).not.toBe(undefined);
         expect(res.nodes[0].data.y).not.toBe(undefined);
       },
-      onLayoutEnd: res => {
-        expect(res.nodes[0].data.x).not.toBe(undefined);
-        expect(res.nodes[0].data.y).not.toBe(undefined);
-        expect(tickCount).toBe(250); // default maxIteration for small graph is 250
-      }
     });
-    fa2.execute(graph);
+    const res = await fa2.execute(graph);
+    expect(res.nodes[0].data.x).not.toBe(undefined);
+    expect(res.nodes[0].data.y).not.toBe(undefined);
+    expect(tickCount).toBe(250); // default maxIteration for small graph is 250
 
     const nodes100: any = [];
     for (let i = 0; i < 101; i++) nodes100.push({ id: i, data: {} });
     const graph2 = new Graph<any, any>({
       nodes: nodes100,
-      edges: []
+      edges: [],
     });
     let tickCount2 = 0;
     const fa22 = new ForceAtlas2Layout({
       center: [100, 200],
-      onTick: res => {
+      onTick: (res) => {
         tickCount2++;
         expect(res.nodes[0].data.x).not.toBe(undefined);
         expect(res.nodes[0].data.y).not.toBe(undefined);
       },
-      onLayoutEnd: res => {
-        expect(res.nodes[0].data.x).not.toBe(undefined);
-        expect(res.nodes[0].data.y).not.toBe(undefined);
-        // nodes more than 100, prune is opened automatically, and the iteration will be 1000 + 100(for prune post-process)
-        expect(tickCount2).toBe(1000 + 100);
-        done()
-      }
     });
-    fa22.execute(graph2);
+    await fa22.execute(graph2);
+    expect(res.nodes[0].data.x).not.toBe(undefined);
+    expect(res.nodes[0].data.y).not.toBe(undefined);
+    // nodes more than 100, prune is opened automatically, and the iteration will be 1000 + 100(for prune post-process)
+    expect(tickCount2).toBe(1000 + 100);
   });
 });

--- a/__tests__/unit/fruchterman.test.ts
+++ b/__tests__/unit/fruchterman.test.ts
@@ -4,21 +4,13 @@ import data from "../data/test-data-1";
 import { getEuclideanDistance } from "../util";
 
 describe("FruchtermanLayout", () => {
-  it("should return correct default config.", (done) => {
+  it("should return correct default config.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
     });
 
-    const start = performance.now();
-    const onLayoutEnd = ({ nodes, edges }) => {
-      console.log("time:", performance.now() - start);
-      expect(nodes[0].data.x).not.toBe(undefined);
-      expect(nodes[0].data.y).not.toBe(undefined);
-      done();
-    };
-
-    const fruchterman = new FruchtermanLayout({ onLayoutEnd });
+    const fruchterman = new FruchtermanLayout();
     expect(fruchterman.options).toEqual({
       maxIteration: 1000,
       gravity: 10,
@@ -28,28 +20,30 @@ describe("FruchtermanLayout", () => {
       width: 300,
       height: 300,
       nodeClusterBy: "cluster",
-      onLayoutEnd,
     });
 
-    fruchterman.execute(graph);
+    const { nodes } = await fruchterman.execute(graph);
     fruchterman.stop();
     fruchterman.tick(1000);
+
+    expect(nodes[0].data.x).not.toBe(undefined);
+    expect(nodes[0].data.y).not.toBe(undefined);
   });
 
-  it("should do fruchterman layout with an empty graph.", () => {
+  it("should do fruchterman layout with an empty graph.", async () => {
     const graph = new Graph<any, any>({
       nodes: [],
       edges: [],
     });
 
     const fruchterman = new FruchtermanLayout();
-    fruchterman.execute(graph);
+    await fruchterman.execute(graph);
     fruchterman.stop();
     const positions = fruchterman.tick(1000);
     expect(JSON.stringify(positions.nodes)).toBe("[]");
   });
 
-  it("should do fruchterman layout with a graph which has only one node.", () => {
+  it("should do fruchterman layout with a graph which has only one node.", async () => {
     const graph = new Graph<any, any>({
       nodes: [{ id: "node", data: {} }],
       edges: [],
@@ -59,7 +53,7 @@ describe("FruchtermanLayout", () => {
       center: [10, 20],
     });
 
-    fruchterman.execute(graph);
+    await fruchterman.execute(graph);
     fruchterman.stop();
     const positions = fruchterman.tick(1000);
 
@@ -67,7 +61,7 @@ describe("FruchtermanLayout", () => {
     expect(positions.nodes[0].data.y).toBe(20);
   });
 
-  it("should do fruchterman layout with clustering and nodeClusterBy.", () => {
+  it("should do fruchterman layout with clustering and nodeClusterBy.", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         { id: "node0", data: { clusterField: "a" } },
@@ -83,7 +77,7 @@ describe("FruchtermanLayout", () => {
       clustering: true,
       nodeClusterBy: "clusterField",
     });
-    fruchterman.execute(graph);
+    await fruchterman.execute(graph);
     fruchterman.stop();
     const positions = fruchterman.tick(1000);
 
@@ -123,19 +117,11 @@ describe("FruchtermanLayout", () => {
     expect(cClusterDist < acClusterDist).toBe(true);
   });
 
-  it("should do fruchterman layout with onTick and onLayoutEnd.", (done) => {
+  it("should do fruchterman layout with onTick and onLayoutEnd.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
     });
-
-    const onLayoutEnd = ({ nodes, edges }) => {
-      expect(nodes.length).toBe(data.nodes.length);
-      expect(nodes[0].data.x).not.toBe(undefined);
-      expect(nodes[0].data.y).not.toBe(undefined);
-      expect(tick).toBe(10);
-      done();
-    };
 
     let tick = 0;
     const onTick = ({ nodes, edges }) => {
@@ -148,9 +134,12 @@ describe("FruchtermanLayout", () => {
     const fruchterman = new FruchtermanLayout({
       maxIteration: 10,
       onTick,
-      onLayoutEnd,
     });
-    fruchterman.execute(graph);
+    const { nodes } = await fruchterman.execute(graph);
+    expect(nodes.length).toBe(data.nodes.length);
+    expect(nodes[0].data.x).not.toBe(undefined);
+    expect(nodes[0].data.y).not.toBe(undefined);
+    expect(tick).toBe(10);
   });
 
   it("should do fruchterman layout with overlapped nodes and loop edge.", () => {

--- a/__tests__/unit/fruchterman.test.ts
+++ b/__tests__/unit/fruchterman.test.ts
@@ -4,7 +4,7 @@ import data from "../data/test-data-1";
 import { getEuclideanDistance } from "../util";
 
 describe("FruchtermanLayout", () => {
-  it("should return correct default config.", async () => {
+  it("should return correct default config.", () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -22,9 +22,9 @@ describe("FruchtermanLayout", () => {
       nodeClusterBy: "cluster",
     });
 
-    const { nodes } = await fruchterman.execute(graph);
+    fruchterman.execute(graph);
     fruchterman.stop();
-    fruchterman.tick(1000);
+    const { nodes } = fruchterman.tick(1000);
 
     expect(nodes[0].data.x).not.toBe(undefined);
     expect(nodes[0].data.y).not.toBe(undefined);
@@ -43,7 +43,7 @@ describe("FruchtermanLayout", () => {
     expect(JSON.stringify(positions.nodes)).toBe("[]");
   });
 
-  it("should do fruchterman layout with a graph which has only one node.", async () => {
+  it("should do fruchterman layout with a graph which has only one node.", () => {
     const graph = new Graph<any, any>({
       nodes: [{ id: "node", data: {} }],
       edges: [],
@@ -53,7 +53,7 @@ describe("FruchtermanLayout", () => {
       center: [10, 20],
     });
 
-    await fruchterman.execute(graph);
+    fruchterman.execute(graph);
     fruchterman.stop();
     const positions = fruchterman.tick(1000);
 
@@ -61,7 +61,7 @@ describe("FruchtermanLayout", () => {
     expect(positions.nodes[0].data.y).toBe(20);
   });
 
-  it("should do fruchterman layout with clustering and nodeClusterBy.", async () => {
+  it("should do fruchterman layout with clustering and nodeClusterBy.", () => {
     const graph = new Graph<any, any>({
       nodes: [
         { id: "node0", data: { clusterField: "a" } },
@@ -77,7 +77,7 @@ describe("FruchtermanLayout", () => {
       clustering: true,
       nodeClusterBy: "clusterField",
     });
-    await fruchterman.execute(graph);
+    fruchterman.execute(graph);
     fruchterman.stop();
     const positions = fruchterman.tick(1000);
 

--- a/__tests__/unit/grid.test.ts
+++ b/__tests__/unit/grid.test.ts
@@ -37,7 +37,7 @@ function isInTheSameCol(nodes) {
 }
 
 describe("GridLayout", () => {
-  it("should return correct default config.", () => {
+  it("should return correct default config.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -58,37 +58,37 @@ describe("GridLayout", () => {
       height: 300,
     });
 
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     expect(positions.nodes[0].data.x).not.toBe(undefined);
     expect(positions.nodes[0].data.y).not.toBe(undefined);
   });
 
-  it("should do grid layout with an empty graph.", () => {
+  it("should do grid layout with an empty graph.", async () => {
     const graph = new Graph<any, any>({
       nodes: [],
       edges: [],
     });
 
     const grid = new GridLayout();
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(positions.nodes).not.toBe(undefined);
   });
 
-  it("should do grid layout with a graph which has only one node.", () => {
+  it("should do grid layout with a graph which has only one node.", async () => {
     const graph = new Graph<any, any>({
       nodes: [{ id: "node", data: {} }],
       edges: [],
     });
 
     const grid = new GridLayout({ begin: [10, 20] });
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     expect(positions.nodes[0].data.x).toBe(10);
     expect(positions.nodes[0].data.y).toBe(20);
   });
 
-  it("should do grid layout with fixed columns.", () => {
+  it("should do grid layout with fixed columns.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -106,7 +106,7 @@ describe("GridLayout", () => {
      * 3 2
      * 1 0
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     // first column
     expect(
@@ -129,7 +129,7 @@ describe("GridLayout", () => {
     ).toEqual(true);
   });
 
-  it("should do grid layout with fixed rows.", () => {
+  it("should do grid layout with fixed rows.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -145,7 +145,7 @@ describe("GridLayout", () => {
      * 7 6 5 4
      * 3 2 1 0
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     // first row
     expect(
@@ -168,7 +168,7 @@ describe("GridLayout", () => {
     ).toEqual(true);
   });
 
-  it("should do grid layout with fixed cols and rows, rows*cols>nodes, situation 1.", () => {
+  it("should do grid layout with fixed cols and rows, rows*cols>nodes, situation 1.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -185,7 +185,7 @@ describe("GridLayout", () => {
      * 7 6 5 4 3
      * 2 1 0
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     expect(
       isInTheSameRow([
@@ -205,7 +205,7 @@ describe("GridLayout", () => {
     ).toEqual(true);
   });
 
-  it("should do grid layout with fixed cols and rows, rows*cols>nodes, situation 2.", () => {
+  it("should do grid layout with fixed cols and rows, rows*cols>nodes, situation 2.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -222,7 +222,7 @@ describe("GridLayout", () => {
      * 7 6 5 4
      * 3 2 1 0
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(
       isInTheSameRow([
         positions.nodes[0],
@@ -241,7 +241,7 @@ describe("GridLayout", () => {
     ).toEqual(true);
   });
 
-  it("should do grid layout with fixed cols and rows, rows*cols<nodes, situation 1", () => {
+  it("should do grid layout with fixed cols and rows, rows*cols<nodes, situation 1", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -260,7 +260,7 @@ describe("GridLayout", () => {
      * 3 2
      * 1 0
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(
       isInTheSameCol([
         positions.nodes[0],
@@ -279,7 +279,7 @@ describe("GridLayout", () => {
     ).toEqual(true);
   });
 
-  it("grid layout with fixed cols and rows, rows*cols<nodes, situation 2", () => {
+  it("grid layout with fixed cols and rows, rows*cols<nodes, situation 2", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -296,7 +296,7 @@ describe("GridLayout", () => {
      * 7 6 5 4
      * 3 2 1 0
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(
       isInTheSameRow([
         positions.nodes[0],
@@ -315,7 +315,7 @@ describe("GridLayout", () => {
     ).toEqual(true);
   });
 
-  it("should do grid layout with condense param.", () => {
+  it("should do grid layout with condense param.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -331,7 +331,7 @@ describe("GridLayout", () => {
      * 6 0 4
      * 5 7
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     expect(
       isInTheSameRow([
@@ -354,7 +354,7 @@ describe("GridLayout", () => {
     );
   });
 
-  it("should do grid layout with preventOverlap", () => {
+  it("should do grid layout with preventOverlap", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -370,7 +370,7 @@ describe("GridLayout", () => {
      * 6 0 4
      * 5 7
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(
       isInTheSameRow([
         positions.nodes[4],
@@ -392,7 +392,7 @@ describe("GridLayout", () => {
     );
   });
 
-  it("grid layout with preventOverlap, nodeSize is an array", () => {
+  it("grid layout with preventOverlap, nodeSize is an array", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -408,7 +408,7 @@ describe("GridLayout", () => {
      * 6 0 4
      * 5 7
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(
       isInTheSameRow([
         positions.nodes[4],
@@ -430,7 +430,7 @@ describe("GridLayout", () => {
     );
   });
 
-  it("should do grid layout with preventOverlap & nodeSize.", () => {
+  it("should do grid layout with preventOverlap & nodeSize.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -446,7 +446,7 @@ describe("GridLayout", () => {
      * 6 0 4
      * 5 7
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
     expect(
       isInTheSameRow([
         positions.nodes[4],
@@ -473,7 +473,7 @@ describe("GridLayout", () => {
     );
   });
 
-  it("should do grid layout with position function", () => {
+  it("should do grid layout with position function", async () => {
     let rows = 0;
     const graph = new Graph<any, any>({
       nodes: [...data.nodes].map((node, i) => {
@@ -505,7 +505,7 @@ describe("GridLayout", () => {
      * 3 4 5
      * 6 7
      */
-    const positions = grid.execute(graph);
+    const positions = await grid.execute(graph);
 
     expect(
       isInTheSameRow([

--- a/__tests__/unit/mds.test.ts
+++ b/__tests__/unit/mds.test.ts
@@ -1,9 +1,9 @@
 import { Graph } from "@antv/graphlib";
 import { MDSLayout } from "@antv/layout";
-import data from '../data/test-data-1';
+import data from "../data/test-data-1";
 
 describe("MDSLayout", () => {
-  it("should return correct default config.", () => {
+  it("should return correct default config.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -15,66 +15,76 @@ describe("MDSLayout", () => {
       linkDistance: 50,
     });
 
-    const positions = mds.execute(graph);
+    const positions = await mds.execute(graph);
 
     expect(positions.nodes[0].data.x).not.toBe(undefined);
     expect(positions.nodes[0].data.y).not.toBe(undefined);
   });
 
-  it("should do mds layout with an empty graph.", () => {
+  it("should do mds layout with an empty graph.", async () => {
     const graph = new Graph<any, any>({
       nodes: [],
       edges: [],
     });
 
     const mds = new MDSLayout();
-    const positions = mds.execute(graph);
+    const positions = await mds.execute(graph);
     expect(positions.nodes).not.toBe(undefined);
   });
 
-  it("should do mds layout with a graph which has only one node.", () => {
+  it("should do mds layout with a graph which has only one node.", async () => {
     const graph = new Graph<any, any>({
       nodes: [{ id: "node", data: {} }],
       edges: [],
     });
 
     const mds = new MDSLayout({ center: [10, 20] });
-    const positions = mds.execute(graph);
+    const positions = await mds.execute(graph);
 
     expect(positions.nodes[0].data.x).toBe(10);
     expect(positions.nodes[0].data.y).toBe(20);
   });
 
-  it("layout unconnected graph", () => {
+  it("layout unconnected graph", async () => {
     const graph = new Graph<any, any>({
       nodes: [
         {
-          id: 'node0',
-          data: {}
+          id: "node0",
+          data: {},
         },
         {
-          id: 'node1',
-          data: {}
+          id: "node1",
+          data: {},
         },
         {
-          id: 'node2',
-          data: {}
+          id: "node2",
+          data: {},
         },
       ],
       edges: [
         {
-          id: 'edge1',
-          source: 'node0',
-          target: 'node1',
-          data: {}
+          id: "edge1",
+          source: "node0",
+          target: "node1",
+          data: {},
         },
       ],
     });
 
     const mds = new MDSLayout({ center: [100, 200] });
-    const positions = mds.execute(graph);
+    const positions = await mds.execute(graph);
 
-    expect((positions.nodes[0].data.x + positions.nodes[1].data.x + positions.nodes[2].data.x) / 3).toBe(100);
-    expect((positions.nodes[0].data.y + positions.nodes[1].data.y + positions.nodes[2].data.y) / 3).toBe(200);
+    expect(
+      (positions.nodes[0].data.x +
+        positions.nodes[1].data.x +
+        positions.nodes[2].data.x) /
+        3
+    ).toBe(100);
+    expect(
+      (positions.nodes[0].data.y +
+        positions.nodes[1].data.y +
+        positions.nodes[2].data.y) /
+        3
+    ).toBe(200);
   });
 });

--- a/__tests__/unit/radial.test.ts
+++ b/__tests__/unit/radial.test.ts
@@ -4,37 +4,37 @@ import { getEuclideanDistance, mathEqual } from "../util";
 
 const data: any = {
   nodes: [
-    { id: '0', label: '0', data: {} },
-    { id: '1', label: '1', data: {} },
-    { id: '2', label: '2', data: {} },
-    { id: '3', label: '3', data: {} },
-    { id: '4', label: '4', data: {} },
-    { id: '5', label: '5', data: {} },
+    { id: "0", label: "0", data: {} },
+    { id: "1", label: "1", data: {} },
+    { id: "2", label: "2", data: {} },
+    { id: "3", label: "3", data: {} },
+    { id: "4", label: "4", data: {} },
+    { id: "5", label: "5", data: {} },
   ],
   edges: [
     {
-      id: 'edge0',
-      source: '0',
-      target: '1',
-      data: {}
+      id: "edge0",
+      source: "0",
+      target: "1",
+      data: {},
     },
     {
-      id: 'edge1',
-      source: '0',
-      target: '2',
-      data: {}
+      id: "edge1",
+      source: "0",
+      target: "2",
+      data: {},
     },
     {
-      id: 'edge2',
-      source: '3',
-      target: '4',
-      data: {}
+      id: "edge2",
+      source: "3",
+      target: "4",
+      data: {},
     },
   ],
 };
 
 describe("RadialLayout", () => {
-  it("should return correct default config.", () => {
+  it("should return correct default config.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],
@@ -52,44 +52,44 @@ describe("RadialLayout", () => {
       strictRadial: true,
       maxPreventOverlapIteration: 200,
       sortBy: undefined,
-      sortStrength: 10
+      sortStrength: 10,
     });
 
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
     const expectCenter = [window.innerWidth / 2, window.innerHeight / 2];
     expect(positions.nodes[0].data.x).toBe(expectCenter[0]);
     expect(positions.nodes[0].data.y).toBe(expectCenter[1]);
   });
 
-  it("should do radial layout with an empty graph.", () => {
+  it("should do radial layout with an empty graph.", async () => {
     const graph = new Graph<any, any>({
       nodes: [],
       edges: [],
     });
 
     const radial = new RadialLayout();
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
     expect(positions.nodes).not.toBe(undefined);
   });
 
-  it("should do radial layout with a graph which has only one node.", () => {
+  it("should do radial layout with a graph which has only one node.", async () => {
     const graph = new Graph<any, any>({
       nodes: [{ id: "node", data: {} }],
       edges: [],
     });
 
     const radial = new RadialLayout({ center: [10, 20] });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
     expect(positions.nodes[0].data.x).toBe(10);
     expect(positions.nodes[0].data.y).toBe(20);
   });
 
-  it ("should do radial layout with unitRadius and linkDistance", () => {
+  it("should do radial layout with unitRadius and linkDistance", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
     const unitRadius = 100;
     const fnIndex = 1;
@@ -105,7 +105,7 @@ describe("RadialLayout", () => {
       unitRadius,
       linkDistance: 100,
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
     const focusPos = positions.nodes[fnIndex];
     const oneStepNode = positions.nodes[0];
@@ -125,24 +125,23 @@ describe("RadialLayout", () => {
     expect(mathEqual(distToDescreteNode1, 3 * unitRadius)).toEqual(true);
     expect(mathEqual(distToDescreteNode2, 3 * unitRadius)).toEqual(true);
     expect(mathEqual(distToDescreteNode3, 4 * unitRadius)).toEqual(true);
-    
   });
 
-  it("should do radial layout with focusNode which is a descrete node", () => {
+  it("should do radial layout with focusNode which is a descrete node", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
     const unitRadius = 100;
-    const focusNodeId = '5';
+    const focusNodeId = "5";
 
     const radial = new RadialLayout({
       focusNode: focusNodeId,
       unitRadius,
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
-    const focusNode = positions.nodes.find(node => node.id === focusNodeId);
+    const focusNode = positions.nodes.find((node) => node.id === focusNodeId);
     const descreteNode1 = positions.nodes[0];
     const descreteNode2 = positions.nodes[1];
     const descreteNode3 = positions.nodes[3];
@@ -159,13 +158,13 @@ describe("RadialLayout", () => {
     expect(mathEqual(distToDescreteNode4, 2 * unitRadius)).toEqual(true);
   });
 
-  it("should do radial layout with preventOverlap, number nodeSpacing, and array nodeSize", () => {
+  it("should do radial layout with preventOverlap, number nodeSpacing, and array nodeSize", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
     const unitRadius = 100;
-    const focusNodeId = '5';
+    const focusNodeId = "5";
     const nodeSize = [40, 20];
     const nodeSpacing = 10;
 
@@ -177,7 +176,7 @@ describe("RadialLayout", () => {
       nodeSpacing,
       nodeSize,
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
     // const focusNode = positions.nodes.find(node => node.id === focusNodeId);
     const overlapNode1 = positions.nodes[2];
@@ -186,19 +185,19 @@ describe("RadialLayout", () => {
     expect(dist > nodeSpacing + Math.max(...nodeSize)).toEqual(true);
   });
 
-  it("should do radial layout with preventOverlap, function nodeSpacing, and size in data", () => {
+  it("should do radial layout with preventOverlap, function nodeSpacing, and size in data", async () => {
     const graph = new Graph<any, any>({
-      nodes: data.nodes.map(node => ({
+      nodes: data.nodes.map((node) => ({
         ...node,
         data: {
           ...node.data,
-          size: [40, 20]
-        }
+          size: [40, 20],
+        },
       })),
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
     const unitRadius = 100;
-    const focusNodeId = '5';
+    const focusNodeId = "5";
     const nodeSpacing = (d) => {
       return 5;
     };
@@ -210,7 +209,7 @@ describe("RadialLayout", () => {
       unitRadius,
       nodeSpacing,
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
     const overlapNode1 = positions.nodes[2];
     const overlapNode2 = positions.nodes[4];
@@ -218,18 +217,18 @@ describe("RadialLayout", () => {
     expect(dist > 5 + 40).toEqual(true);
   });
 
-  it("should do radial layout with sortBy: 'data' ", () => {
+  it("should do radial layout with sortBy: 'data' ", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
-    const focusNodeId = '5';
+    const focusNodeId = "5";
 
     const radial = new RadialLayout({
       focusNode: focusNodeId,
-      sortBy: 'data',
+      sortBy: "data",
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
     // keeps relative order in data.nodes
     if (positions.nodes[4].data.y < positions.nodes[2].data.y) {
       expect(positions.nodes[2].data.y < positions.nodes[1].data.y).toBe(true);
@@ -238,48 +237,57 @@ describe("RadialLayout", () => {
     }
   });
 
-  it("should do radial layout with sortBy: 'sortProperty' ", () => {
+  it("should do radial layout with sortBy: 'sortProperty' ", async () => {
     const graph = new Graph<any, any>({
       nodes: data.nodes.map((node, i) => ({
         ...node,
         data: {
           ...node.data,
-          sortProperty: i % 2
-        }
+          sortProperty: i % 2,
+        },
       })),
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
-    const focusNodeId = '5';
+    const focusNodeId = "5";
 
     const radial = new RadialLayout({
       focusNode: focusNodeId,
-      sortBy: 'sortProperty',
+      sortBy: "sortProperty",
       sortStrength: 1000,
       preventOverlap: true,
       maxPreventOverlapIteration: 2000,
-      nodeSize: 50
+      nodeSize: 50,
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
-    const sameClusterNodeDist = getEuclideanDistance(positions.nodes[4], positions.nodes[2]);
-    const differentClusterNodeDist1 = getEuclideanDistance(positions.nodes[2], positions.nodes[1]);
-    const differentClusterNodeDist2 = getEuclideanDistance(positions.nodes[4], positions.nodes[1]);
+    const sameClusterNodeDist = getEuclideanDistance(
+      positions.nodes[4],
+      positions.nodes[2]
+    );
+    const differentClusterNodeDist1 = getEuclideanDistance(
+      positions.nodes[2],
+      positions.nodes[1]
+    );
+    const differentClusterNodeDist2 = getEuclideanDistance(
+      positions.nodes[4],
+      positions.nodes[1]
+    );
     expect(mathEqual(sameClusterNodeDist, 50)).toBe(true);
     expect(sameClusterNodeDist < differentClusterNodeDist1).toBe(true);
     expect(sameClusterNodeDist < differentClusterNodeDist2).toBe(true);
   });
 
-  it("should not do radial layout with inexistent focusNode", () => {
+  it("should not do radial layout with inexistent focusNode", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
-      edges: [...data.edges]
+      edges: [...data.edges],
     });
 
     const radial = new RadialLayout({
-      focusNode: 'id-inexistent',
-      center: [10, 20]
+      focusNode: "id-inexistent",
+      center: [10, 20],
     });
-    const positions = radial.execute(graph);
+    const positions = await radial.execute(graph);
 
     // focusNode will be the first node
     expect(positions.nodes[0].data.x).toBe(10);

--- a/demo/circular.html
+++ b/demo/circular.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -896,37 +896,39 @@
         radius: 200,
       });
 
-      const positions = circular.execute(graph);
-      console.log(positions);
+      (async () => {
+        const positions = await circular.execute(graph);
+        console.log(positions);
 
-      const { Circle, Canvas } = window.G;
+        const { Circle, Canvas } = window.G;
 
-      // create a renderer
-      const canvasRenderer = new window.G.Canvas2D.Renderer();
+        // create a renderer
+        const canvasRenderer = new window.G.Canvas2D.Renderer();
 
-      // create a canvas
-      const canvas = new Canvas({
-        container: "container",
-        width: 500,
-        height: 500,
-        renderer: canvasRenderer,
-      });
-
-      canvas.addEventListener("ready", () => {
-        positions.nodes.forEach((node) => {
-          const circle = new Circle({
-            style: {
-              cx: node.data.x,
-              cy: node.data.y,
-              r: 10,
-              fill: "#1890FF",
-              stroke: "#F04864",
-              lineWidth: 4,
-            },
-          });
-          canvas.appendChild(circle);
+        // create a canvas
+        const canvas = new Canvas({
+          container: "container",
+          width: 500,
+          height: 500,
+          renderer: canvasRenderer,
         });
-      });
+
+        canvas.addEventListener("ready", () => {
+          positions.nodes.forEach((node) => {
+            const circle = new Circle({
+              style: {
+                cx: node.data.x,
+                cy: node.data.y,
+                r: 10,
+                fill: "#1890FF",
+                stroke: "#F04864",
+                lineWidth: 4,
+              },
+            });
+            canvas.appendChild(circle);
+          });
+        });
+      })();
     </script>
   </body>
 </html>

--- a/demo/concentric.html
+++ b/demo/concentric.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -65,8 +65,6 @@
             height: 400,
           });
 
-          const positions = circular.execute(graph);
-
           const { Circle, Canvas } = window.G;
 
           // create a renderer
@@ -80,21 +78,25 @@
             renderer: canvasRenderer,
           });
 
-          canvas.addEventListener("ready", () => {
-            positions.nodes.forEach((node) => {
-              const circle = new Circle({
-                style: {
-                  cx: node.data.x,
-                  cy: node.data.y,
-                  r: 10,
-                  fill: "#1890FF",
-                  stroke: "#F04864",
-                  lineWidth: 4,
-                },
+          (async () => {
+            const positions = await circular.execute(graph);
+
+            canvas.addEventListener("ready", () => {
+              positions.nodes.forEach((node) => {
+                const circle = new Circle({
+                  style: {
+                    cx: node.data.x,
+                    cy: node.data.y,
+                    r: 10,
+                    fill: "#1890FF",
+                    stroke: "#F04864",
+                    lineWidth: 4,
+                  },
+                });
+                canvas.appendChild(circle);
               });
-              canvas.appendChild(circle);
             });
-          });
+          })();
         });
     </script>
   </body>

--- a/demo/d3force.html
+++ b/demo/d3force.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -302,22 +302,21 @@
             });
           };
 
-          force.assign(graph, {
-            center: [200, 200], // The center of the graph by default
-            preventOverlap: true,
-            nodeSize: 20,
-            onTick: (positions) => {
-              if (!rendered) {
-                createNodesEdges(positions);
-                rendered = true;
-              } else {
-                updateNodesEdges(positions);
-              }
-            },
-            onLayoutEnd: (positions) => {
-              console.log(positions);
-            },
-          });
+          (async () => {
+            await force.assign(graph, {
+              center: [200, 200], // The center of the graph by default
+              preventOverlap: true,
+              nodeSize: 20,
+              onTick: (positions) => {
+                if (!rendered) {
+                  createNodesEdges(positions);
+                  rendered = true;
+                } else {
+                  updateNodesEdges(positions);
+                }
+              },
+            });
+          })();
         });
     </script>
   </body>

--- a/demo/d3force.stop.html
+++ b/demo/d3force.stop.html
@@ -301,14 +301,35 @@
             });
           };
 
+          let rendered = false;
           force.assign(graph, {
             center: [200, 200], // The center of the graph by default
             preventOverlap: true,
             nodeSize: 20,
+            onTick: (positions) => {
+              if (!rendered) {
+                createNodesEdges(positions);
+                rendered = true;
+              } else {
+                updateNodesEdges(positions);
+              }
+            },
           });
-          force.stop();
-          const positions = force.tick(1000);
-          createNodesEdges(positions);
+
+          setTimeout(() => {
+            force.stop();
+          }, 100);
+
+          setTimeout(() => {
+            force.assign(graph, {
+              center: [200, 200], // The center of the graph by default
+              preventOverlap: true,
+              nodeSize: 20,
+              onTick: (positions) => {
+                updateNodesEdges(positions);
+              },
+            });
+          }, 1500);
         });
     </script>
   </body>

--- a/demo/force.html
+++ b/demo/force.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -1011,9 +1011,6 @@
           } else {
             updateNodesEdges(positions);
           }
-        },
-        onLayoutEnd: (positions) => {
-          console.log(positions);
         },
       });
     </script>

--- a/demo/force.stop.html
+++ b/demo/force.stop.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width,initial-scale=1,shrink-to-fit=no"
     />
-    <title>D3Force</title>
+    <title>Force</title>
     <style>
       * {
         box-sizing: border-box;
@@ -50,7 +50,7 @@
     ></script>
     <script>
       const { Graph } = window.GraphLib;
-      const { D3ForceLayout } = window.Layout;
+      const { ForceLayout } = window.Layout;
 
       fetch(
         "https://gw.alipayobjects.com/os/antvdemo/assets/data/relations.json"
@@ -203,8 +203,9 @@
             edges: data.edges.map((edge, i) => ({ id: i, ...edge })),
           });
 
-          const force = new D3ForceLayout();
+          const force = new ForceLayout();
 
+          let rendered = false;
           const nodes = [];
           const edges = [];
 
@@ -253,9 +254,6 @@
                 });
                 force.stop();
                 force.assign(graph, {
-                  center: [200, 200], // The center of the graph by default
-                  preventOverlap: true,
-                  nodeSize: 20,
                   onTick: (positions) => {
                     updateNodesEdges(positions);
                   },
@@ -305,10 +303,30 @@
             center: [200, 200], // The center of the graph by default
             preventOverlap: true,
             nodeSize: 20,
+            onTick: (positions) => {
+              if (!rendered) {
+                createNodesEdges(positions);
+                rendered = true;
+              } else {
+                updateNodesEdges(positions);
+              }
+            },
           });
-          force.stop();
-          const positions = force.tick(1000);
-          createNodesEdges(positions);
+
+          setTimeout(() => {
+            force.stop();
+          }, 100);
+
+          setTimeout(() => {
+            force.assign(graph, {
+              center: [200, 200], // The center of the graph by default
+              preventOverlap: true,
+              nodeSize: 20,
+              onTick: (positions) => {
+                updateNodesEdges(positions);
+              },
+            });
+          }, 1500);
         });
     </script>
   </body>

--- a/demo/force.tick.html
+++ b/demo/force.tick.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script

--- a/demo/forceAtlas2.html
+++ b/demo/forceAtlas2.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -65,7 +65,6 @@
             preventOverlap: true,
           });
 
-          const positions = force.execute(graph);
           const { Circle, Line, Canvas } = window.G;
 
           // create a renderer
@@ -79,41 +78,45 @@
             renderer: canvasRenderer,
           });
 
-          canvas.addEventListener("ready", () => {
-            positions.edges.forEach(({ source, target }, i) => {
-              const sourceNode = positions.nodes.find(
-                ({ id }) => id === source
-              );
-              const targetNode = positions.nodes.find(
-                ({ id }) => id === target
-              );
-              const line = new Line({
-                style: {
-                  x1: sourceNode.data.x,
-                  y1: sourceNode.data.y,
-                  x2: targetNode.data.x,
-                  y2: targetNode.data.y,
-                  lineWidth: 1,
-                  stroke: "grey",
-                },
-              });
-              canvas.appendChild(line);
-            });
+          (async () => {
+            const positions = await force.execute(graph);
 
-            positions.nodes.forEach((node) => {
-              const circle = new Circle({
-                style: {
-                  cx: node.data.x,
-                  cy: node.data.y,
-                  r: 10,
-                  fill: "#1890FF",
-                  stroke: "#F04864",
-                  lineWidth: 4,
-                },
+            canvas.addEventListener("ready", () => {
+              positions.edges.forEach(({ source, target }, i) => {
+                const sourceNode = positions.nodes.find(
+                  ({ id }) => id === source
+                );
+                const targetNode = positions.nodes.find(
+                  ({ id }) => id === target
+                );
+                const line = new Line({
+                  style: {
+                    x1: sourceNode.data.x,
+                    y1: sourceNode.data.y,
+                    x2: targetNode.data.x,
+                    y2: targetNode.data.y,
+                    lineWidth: 1,
+                    stroke: "grey",
+                  },
+                });
+                canvas.appendChild(line);
               });
-              canvas.appendChild(circle);
+
+              positions.nodes.forEach((node) => {
+                const circle = new Circle({
+                  style: {
+                    cx: node.data.x,
+                    cy: node.data.y,
+                    r: 10,
+                    fill: "#1890FF",
+                    stroke: "#F04864",
+                    lineWidth: 4,
+                  },
+                });
+                canvas.appendChild(circle);
+              });
             });
-          });
+          })();
         });
     </script>
   </body>

--- a/demo/fruchterman.gpu.html
+++ b/demo/fruchterman.gpu.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -961,11 +961,10 @@
               y: canvasY - shiftY,
             });
             // fruchterman.stop();
-            fruchterman.assign(graph, {
-              onLayoutEnd: (positions) => {
-                updateNodesEdges(positions);
-              },
-            });
+            // (async () => {
+            //   const positions = await fruchterman.execute(graph);
+            //   updateNodesEdges(positions);
+            // })();
           }
 
           circle.addEventListener("dragstart", function (e) {
@@ -1003,11 +1002,10 @@
         });
       };
 
-      fruchterman.assign(graph, {
-        onLayoutEnd: (positions) => {
-          createNodesEdges(positions);
-        },
-      });
+      (async () => {
+        const positions = await fruchterman.execute(graph);
+        createNodesEdges(positions);
+      })();
     </script>
   </body>
 </html>

--- a/demo/fruchterman.stop.html
+++ b/demo/fruchterman.stop.html
@@ -1009,6 +1009,17 @@
           }
         },
       });
+      setTimeout(() => {
+        fruchterman.stop();
+      }, 100);
+
+      setTimeout(() => {
+        fruchterman.assign(graph, {
+          onTick: (positions) => {
+            updateNodesEdges(positions);
+          },
+        });
+      }, 1200);
     </script>
   </body>
 </html>

--- a/demo/fruchterman.tick.html
+++ b/demo/fruchterman.tick.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -999,19 +999,21 @@
         });
       };
 
-      fruchterman.assign(graph);
-      // Do static layout.
-      fruchterman.stop();
-      const positions = fruchterman.tick(1000);
-      // Render nodes.
-      createNodesEdges(positions);
-      // Update Graph model.
-      positions.nodes.forEach((node) =>
-        graph.mergeNodeData(node.id, {
-          x: node.data.x,
-          y: node.data.y,
-        })
-      );
+      (async () => {
+        fruchterman.assign(graph);
+        // Do static layout.
+        fruchterman.stop();
+        const positions = fruchterman.tick(1000);
+        // Render nodes.
+        createNodesEdges(positions);
+        // Update Graph model.
+        positions.nodes.forEach((node) =>
+          graph.mergeNodeData(node.id, {
+            x: node.data.x,
+            y: node.data.y,
+          })
+        );
+      })();
     </script>
   </body>
 </html>

--- a/demo/gforce.gpu.html
+++ b/demo/gforce.gpu.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -914,10 +914,10 @@
 
       const fruchterman = new GForceLayout({
         width: 500,
-        height: 600,
+        height: 500,
+        center: [250, 250],
       });
 
-      let rendered = false;
       const nodes = [];
       const edges = [];
 
@@ -952,54 +952,6 @@
             },
           });
           canvas.appendChild(circle);
-
-          let shiftX = 0;
-          let shiftY = 0;
-          function moveAt(target, canvasX, canvasY) {
-            graph.mergeNodeData(positions.nodes[i].id, {
-              x: canvasX - shiftX,
-              y: canvasY - shiftY,
-            });
-            // fruchterman.stop();
-            fruchterman.assign(graph, {
-              onLayoutEnd: (positions) => {
-                updateNodesEdges(positions);
-              },
-            });
-          }
-
-          circle.addEventListener("dragstart", function (e) {
-            const [x, y] = e.target.getPosition();
-            shiftX = e.canvasX - x;
-            shiftY = e.canvasY - y;
-
-            moveAt(e.target, e.canvasX, e.canvasY);
-          });
-          circle.addEventListener("drag", function (e) {
-            moveAt(e.target, e.canvasX, e.canvasY);
-          });
-          nodes.push(circle);
-        });
-      };
-
-      const updateNodesEdges = (positions) => {
-        positions.edges.forEach(({ source, target }, i) => {
-          const sourceNode = positions.nodes.find(({ id }) => id === source);
-          const targetNode = positions.nodes.find(({ id }) => id === target);
-
-          edges[i].attr({
-            x1: sourceNode.data.x,
-            y1: sourceNode.data.y,
-            x2: targetNode.data.x,
-            y2: targetNode.data.y,
-          });
-        });
-
-        positions.nodes.forEach((node, i) => {
-          nodes[i].attr({
-            cx: node.data.x,
-            cy: node.data.y,
-          });
         });
       };
 

--- a/demo/grid.html
+++ b/demo/grid.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -80,8 +80,6 @@
         begin: [10, 20],
       });
 
-      const positions = grid.execute(graph);
-
       const { Circle, Line, Text, Canvas } = window.G;
 
       // create a renderer
@@ -95,49 +93,53 @@
         renderer: canvasRenderer,
       });
 
-      canvas.addEventListener("ready", () => {
-        positions.edges.forEach(({ source, target }) => {
-          const sourceNode = positions.nodes.find(({ id }) => id === source);
-          const targetNode = positions.nodes.find(({ id }) => id === target);
-          const line = new Line({
-            style: {
-              x1: sourceNode.data.x,
-              y1: sourceNode.data.y,
-              x2: targetNode.data.x,
-              y2: targetNode.data.y,
-              lineWidth: 1,
-              stroke: "grey",
-            },
-          });
-          canvas.appendChild(line);
-        });
+      (async () => {
+        const positions = await grid.execute(graph);
 
-        positions.nodes.forEach((node) => {
-          const circle = new Circle({
-            style: {
-              cx: node.data.x,
-              cy: node.data.y,
-              r: 10,
-              fill: "#1890FF",
-              stroke: "#F04864",
-              lineWidth: 4,
-            },
+        canvas.addEventListener("ready", () => {
+          positions.edges.forEach(({ source, target }) => {
+            const sourceNode = positions.nodes.find(({ id }) => id === source);
+            const targetNode = positions.nodes.find(({ id }) => id === target);
+            const line = new Line({
+              style: {
+                x1: sourceNode.data.x,
+                y1: sourceNode.data.y,
+                x2: targetNode.data.x,
+                y2: targetNode.data.y,
+                lineWidth: 1,
+                stroke: "grey",
+              },
+            });
+            canvas.appendChild(line);
           });
-          canvas.appendChild(circle);
 
-          const text = new Text({
-            style: {
-              x: node.data.x,
-              y: node.data.y,
-              text: node.data.name || node.id,
-              fontSize: 12,
-              textAlign: "center",
-              textBaseline: "middle",
-            },
+          positions.nodes.forEach((node) => {
+            const circle = new Circle({
+              style: {
+                cx: node.data.x,
+                cy: node.data.y,
+                r: 10,
+                fill: "#1890FF",
+                stroke: "#F04864",
+                lineWidth: 4,
+              },
+            });
+            canvas.appendChild(circle);
+
+            const text = new Text({
+              style: {
+                x: node.data.x,
+                y: node.data.y,
+                text: node.data.name || node.id,
+                fontSize: 12,
+                textAlign: "center",
+                textBaseline: "middle",
+              },
+            });
+            canvas.appendChild(text);
           });
-          canvas.appendChild(text);
         });
-      });
+      })();
     </script>
   </body>
 </html>

--- a/demo/mds.html
+++ b/demo/mds.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -896,9 +896,6 @@
         linkDistance: 50,
       });
 
-      const positions = mds.execute(graph);
-      console.log(positions);
-
       const { Circle, Canvas } = window.G;
 
       // create a renderer
@@ -912,21 +909,26 @@
         renderer: canvasRenderer,
       });
 
-      canvas.addEventListener("ready", () => {
-        positions.nodes.forEach((node) => {
-          const circle = new Circle({
-            style: {
-              cx: node.data.x,
-              cy: node.data.y,
-              r: 10,
-              fill: "#1890FF",
-              stroke: "#F04864",
-              lineWidth: 4,
-            },
+      (async () => {
+        const positions = await mds.execute(graph);
+        console.log(positions);
+
+        canvas.addEventListener("ready", () => {
+          positions.nodes.forEach((node) => {
+            const circle = new Circle({
+              style: {
+                cx: node.data.x,
+                cy: node.data.y,
+                r: 10,
+                fill: "#1890FF",
+                stroke: "#F04864",
+                lineWidth: 4,
+              },
+            });
+            canvas.appendChild(circle);
           });
-          canvas.appendChild(circle);
         });
-      });
+      })();
     </script>
   </body>
 </html>

--- a/demo/radial.html
+++ b/demo/radial.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -894,13 +894,10 @@
       const radial = new RadialLayout({
         width: 500,
         height: 600,
-        focusNode: 'Australia',
+        focusNode: "Australia",
         unitRadius: 100,
         linkDistance: 100,
       });
-
-      const positions = radial.execute(graph);
-      console.log(positions);
 
       const { Circle, Canvas } = window.G;
 
@@ -915,21 +912,25 @@
         renderer: canvasRenderer,
       });
 
-      canvas.addEventListener("ready", () => {
-        positions.nodes.forEach((node) => {
-          const circle = new Circle({
-            style: {
-              cx: node.data.x,
-              cy: node.data.y,
-              r: 10,
-              fill: "#1890FF",
-              stroke: "#F04864",
-              lineWidth: 4,
-            },
+      (async () => {
+        const positions = await radial.execute(graph);
+        console.log(positions);
+        canvas.addEventListener("ready", () => {
+          positions.nodes.forEach((node) => {
+            const circle = new Circle({
+              style: {
+                cx: node.data.x,
+                cy: node.data.y,
+                r: 10,
+                fill: "#1890FF",
+                stroke: "#F04864",
+                lineWidth: 4,
+              },
+            });
+            canvas.appendChild(circle);
           });
-          canvas.appendChild(circle);
         });
-      });
+      })();
     </script>
   </body>
 </html>

--- a/demo/supervisor.concentric.html
+++ b/demo/supervisor.concentric.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -48,87 +48,81 @@
       const { Graph } = window.GraphLib;
       const { ConcentricLayout, Supervisor } = window.Layout;
 
-      fetch(
-        "https://gw.alipayobjects.com/os/basement_prod/8dacf27e-e1bc-4522-b6d3-4b6d9b9ed7df.json"
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          const formattedNodes = data.nodes.map((node) => {
-            const { id, ...others } = node;
-            return {
-              id,
-              data: {
-                ...others,
-              },
-            };
-          });
+      (async () => {
+        const res = await fetch(
+          "https://gw.alipayobjects.com/os/basement_prod/8dacf27e-e1bc-4522-b6d3-4b6d9b9ed7df.json"
+        );
+        const data = await res.json();
 
-          const graph = new Graph({
-            nodes: formattedNodes,
-            edges: data.edges,
-          });
-
-          const concenric = new ConcentricLayout({
-            maxLevelDiff: 0.5,
-            center: [200, 200],
-            width: 400,
-            height: 400,
-          });
-
-          const supervisor = new Supervisor(graph, concenric);
-          supervisor.on("layoutend", (positions) => {
-            const { Circle, Line, Canvas } = window.G;
-
-            // create a renderer
-            const canvasRenderer = new window.G.Canvas2D.Renderer();
-
-            // create a canvas
-            const canvas = new Canvas({
-              container: "container",
-              width: 500,
-              height: 500,
-              renderer: canvasRenderer,
-            });
-
-            canvas.addEventListener("ready", () => {
-              positions.edges.forEach(({ source, target }, i) => {
-                const sourceNode = positions.nodes.find(
-                  ({ id }) => id === source
-                );
-                const targetNode = positions.nodes.find(
-                  ({ id }) => id === target
-                );
-                const line = new Line({
-                  style: {
-                    x1: sourceNode.data.x,
-                    y1: sourceNode.data.y,
-                    x2: targetNode.data.x,
-                    y2: targetNode.data.y,
-                    lineWidth: 1,
-                    stroke: "grey",
-                  },
-                });
-                canvas.appendChild(line);
-              });
-
-              positions.nodes.forEach((node) => {
-                const circle = new Circle({
-                  style: {
-                    cx: node.data.x,
-                    cy: node.data.y,
-                    r: 10,
-                    fill: "#1890FF",
-                    stroke: "#F04864",
-                    lineWidth: 4,
-                  },
-                });
-                canvas.appendChild(circle);
-              });
-            });
-          });
-
-          supervisor.start();
+        const formattedNodes = data.nodes.map((node) => {
+          const { id, ...others } = node;
+          return {
+            id,
+            data: {
+              ...others,
+            },
+          };
         });
+
+        const graph = new Graph({
+          nodes: formattedNodes,
+          edges: data.edges,
+        });
+
+        const concenric = new ConcentricLayout({
+          maxLevelDiff: 0.5,
+          center: [200, 200],
+          width: 400,
+          height: 400,
+        });
+
+        const { Circle, Line, Canvas } = window.G;
+
+        // create a renderer
+        const canvasRenderer = new window.G.Canvas2D.Renderer();
+
+        // create a canvas
+        const canvas = new Canvas({
+          container: "container",
+          width: 500,
+          height: 500,
+          renderer: canvasRenderer,
+        });
+        await canvas.ready;
+
+        const supervisor = new Supervisor(graph, concenric);
+        const positions = await supervisor.execute();
+
+        positions.edges.forEach(({ source, target }, i) => {
+          const sourceNode = positions.nodes.find(({ id }) => id === source);
+          const targetNode = positions.nodes.find(({ id }) => id === target);
+          const line = new Line({
+            style: {
+              x1: sourceNode.data.x,
+              y1: sourceNode.data.y,
+              x2: targetNode.data.x,
+              y2: targetNode.data.y,
+              lineWidth: 1,
+              stroke: "grey",
+            },
+          });
+          canvas.appendChild(line);
+        });
+
+        positions.nodes.forEach((node) => {
+          const circle = new Circle({
+            style: {
+              cx: node.data.x,
+              cy: node.data.y,
+              r: 10,
+              fill: "#1890FF",
+              stroke: "#F04864",
+              lineWidth: 4,
+            },
+          });
+          canvas.appendChild(circle);
+        });
+      })();
     </script>
   </body>
 </html>

--- a/demo/supervisor.d3force.html
+++ b/demo/supervisor.d3force.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -1004,8 +1004,9 @@
         });
       };
 
-      // Do first-time static layout on worker-side.
-      supervisor.on("layoutend", (positions) => {
+      (async () => {
+        // Do first-time static layout on worker-side.
+        const positions = await supervisor.execute();
         // Update Graph model.
         positions.nodes.forEach((node) =>
           graph.mergeNodeData(node.id, {
@@ -1015,9 +1016,9 @@
         );
 
         // Render.
+        await canvas.ready;
         createNodesEdges(positions);
-      });
-      supervisor.start();
+      })();
     </script>
   </body>
 </html>

--- a/demo/supervisor.force.html
+++ b/demo/supervisor.force.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -1000,10 +1000,10 @@
         });
       };
 
-      // Do first-time static layout on worker-side.
-      supervisor.on("layoutend", (positions) => {
+      (async () => {
+        // Do first-time static layout on worker-side.
+        const positions = await supervisor.execute();
         console.log(positions);
-
         // Update Graph model.
         positions.nodes.forEach((node) =>
           graph.mergeNodeData(node.id, {
@@ -1013,9 +1013,9 @@
         );
 
         // Render.
+        await canvas.ready;
         createNodesEdges(positions);
-      });
-      supervisor.start();
+      })();
     </script>
   </body>
 </html>

--- a/demo/supervisor.forceAtlas2.html
+++ b/demo/supervisor.forceAtlas2.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -48,87 +48,81 @@
       const { Graph } = window.GraphLib;
       const { ForceAtlas2Layout, Supervisor } = window.Layout;
 
-      fetch(
-        "https://gw.alipayobjects.com/os/basement_prod/8dacf27e-e1bc-4522-b6d3-4b6d9b9ed7df.json"
-      )
-        .then((res) => res.json())
-        .then((data) => {
-          const formattedNodes = data.nodes.map((node) => {
-            const { id, ...others } = node;
-            return {
-              id,
-              data: {
-                ...others,
-              },
-            };
-          });
+      (async () => {
+        const res = await fetch(
+          "https://gw.alipayobjects.com/os/basement_prod/8dacf27e-e1bc-4522-b6d3-4b6d9b9ed7df.json"
+        );
+        const data = await res.json();
 
-          const graph = new Graph({
-            nodes: formattedNodes,
-            edges: data.edges,
-          });
-
-          const force = new ForceAtlas2Layout({
-            center: [200, 200],
-            width: 400,
-            height: 400,
-            preventOverlap: true,
-          });
-
-          const supervisor = new Supervisor(graph, force);
-          supervisor.on("layoutend", (positions) => {
-            const { Circle, Line, Canvas } = window.G;
-
-            // create a renderer
-            const canvasRenderer = new window.G.Canvas2D.Renderer();
-
-            // create a canvas
-            const canvas = new Canvas({
-              container: "container",
-              width: 500,
-              height: 500,
-              renderer: canvasRenderer,
-            });
-
-            canvas.addEventListener("ready", () => {
-              positions.edges.forEach(({ source, target }, i) => {
-                const sourceNode = positions.nodes.find(
-                  ({ id }) => id === source
-                );
-                const targetNode = positions.nodes.find(
-                  ({ id }) => id === target
-                );
-                const line = new Line({
-                  style: {
-                    x1: sourceNode.data.x,
-                    y1: sourceNode.data.y,
-                    x2: targetNode.data.x,
-                    y2: targetNode.data.y,
-                    lineWidth: 1,
-                    stroke: "grey",
-                  },
-                });
-                canvas.appendChild(line);
-              });
-
-              positions.nodes.forEach((node) => {
-                const circle = new Circle({
-                  style: {
-                    cx: node.data.x,
-                    cy: node.data.y,
-                    r: 10,
-                    fill: "#1890FF",
-                    stroke: "#F04864",
-                    lineWidth: 4,
-                  },
-                });
-                canvas.appendChild(circle);
-              });
-            });
-          });
-
-          supervisor.start();
+        const formattedNodes = data.nodes.map((node) => {
+          const { id, ...others } = node;
+          return {
+            id,
+            data: {
+              ...others,
+            },
+          };
         });
+
+        const graph = new Graph({
+          nodes: formattedNodes,
+          edges: data.edges,
+        });
+
+        const force = new ForceAtlas2Layout({
+          center: [200, 200],
+          width: 400,
+          height: 400,
+          preventOverlap: true,
+        });
+
+        const supervisor = new Supervisor(graph, force);
+        const { Circle, Line, Canvas } = window.G;
+
+        // create a renderer
+        const canvasRenderer = new window.G.Canvas2D.Renderer();
+
+        // create a canvas
+        const canvas = new Canvas({
+          container: "container",
+          width: 500,
+          height: 500,
+          renderer: canvasRenderer,
+        });
+
+        await canvas.ready;
+        const positions = await supervisor.execute();
+
+        positions.edges.forEach(({ source, target }, i) => {
+          const sourceNode = positions.nodes.find(({ id }) => id === source);
+          const targetNode = positions.nodes.find(({ id }) => id === target);
+          const line = new Line({
+            style: {
+              x1: sourceNode.data.x,
+              y1: sourceNode.data.y,
+              x2: targetNode.data.x,
+              y2: targetNode.data.y,
+              lineWidth: 1,
+              stroke: "grey",
+            },
+          });
+          canvas.appendChild(line);
+        });
+
+        positions.nodes.forEach((node) => {
+          const circle = new Circle({
+            style: {
+              cx: node.data.x,
+              cy: node.data.y,
+              r: 10,
+              fill: "#1890FF",
+              stroke: "#F04864",
+              lineWidth: 4,
+            },
+          });
+          canvas.appendChild(circle);
+        });
+      })();
     </script>
   </body>
 </html>

--- a/demo/supervisor.fruchterman.html
+++ b/demo/supervisor.fruchterman.html
@@ -41,7 +41,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -52,273 +52,261 @@
       const { Graph } = window.GraphLib;
       const { FruchtermanLayout, Supervisor } = window.Layout;
 
-      fetch(
-        "https://gw.alipayobjects.com/os/antvdemo/assets/data/relations.json"
-      )
-        .then((res) => res.json())
-        .then((d) => {
-          const data = {
-            nodes: [
-              {
-                id: "0",
-                data: {
-                  label: "0",
-                },
+      (async () => {
+        const data = {
+          nodes: [
+            {
+              id: "0",
+              data: {
+                label: "0",
               },
-              {
-                id: "1",
-                data: {
-                  label: "1",
-                },
+            },
+            {
+              id: "1",
+              data: {
+                label: "1",
               },
-              {
-                id: "2",
-                data: {
-                  label: "2",
-                },
+            },
+            {
+              id: "2",
+              data: {
+                label: "2",
               },
-              {
-                id: "3",
-                data: {
-                  label: "3",
-                },
+            },
+            {
+              id: "3",
+              data: {
+                label: "3",
               },
-              {
-                id: "4",
-                data: {
-                  label: "4",
-                },
+            },
+            {
+              id: "4",
+              data: {
+                label: "4",
               },
-              {
-                id: "5",
-                data: {
-                  label: "5",
-                },
+            },
+            {
+              id: "5",
+              data: {
+                label: "5",
               },
-              {
-                id: "6",
-                data: {
-                  label: "6",
-                },
+            },
+            {
+              id: "6",
+              data: {
+                label: "6",
               },
-              {
-                id: "7",
-                data: {
-                  label: "7",
-                },
+            },
+            {
+              id: "7",
+              data: {
+                label: "7",
               },
-              {
-                id: "8",
-                data: {
-                  label: "8",
-                },
+            },
+            {
+              id: "8",
+              data: {
+                label: "8",
               },
-              {
-                id: "9",
-                data: {
-                  label: "9",
-                },
+            },
+            {
+              id: "9",
+              data: {
+                label: "9",
               },
-            ],
-            edges: [
-              {
-                source: "0",
-                target: "1",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "2",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "3",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "4",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "5",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "7",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "8",
-                data: {},
-              },
-              {
-                source: "0",
-                target: "9",
-                data: {},
-              },
-              {
-                source: "2",
-                target: "3",
-                data: {},
-              },
-              {
-                source: "4",
-                target: "5",
-                data: {},
-              },
-              {
-                source: "4",
-                target: "6",
-                data: {},
-              },
-              {
-                source: "5",
-                target: "6",
-                data: {},
-              },
-            ],
-          };
+            },
+          ],
+          edges: [
+            {
+              source: "0",
+              target: "1",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "2",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "3",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "4",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "5",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "7",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "8",
+              data: {},
+            },
+            {
+              source: "0",
+              target: "9",
+              data: {},
+            },
+            {
+              source: "2",
+              target: "3",
+              data: {},
+            },
+            {
+              source: "4",
+              target: "5",
+              data: {},
+            },
+            {
+              source: "4",
+              target: "6",
+              data: {},
+            },
+            {
+              source: "5",
+              target: "6",
+              data: {},
+            },
+          ],
+        };
 
-          const { Circle, Line, Canvas } = window.G;
-          // create a renderer
-          const canvasRenderer = new window.G.Canvas2D.Renderer();
-          const plugin = new window.G.Dragndrop.Plugin();
-          canvasRenderer.registerPlugin(plugin);
+        const { Circle, Line, Canvas } = window.G;
+        // create a renderer
+        const canvasRenderer = new window.G.Canvas2D.Renderer();
+        const plugin = new window.G.Dragndrop.Plugin();
+        canvasRenderer.registerPlugin(plugin);
 
-          // create a canvas
-          const canvas = new Canvas({
-            container: "container",
-            width: 500,
-            height: 500,
-            renderer: canvasRenderer,
-          });
+        // create a canvas
+        const canvas = new Canvas({
+          container: "container",
+          width: 500,
+          height: 500,
+          renderer: canvasRenderer,
+        });
+        await canvas.ready;
 
-          const graph = new Graph({
-            nodes: data.nodes,
-            edges: data.edges.map((edge, i) => ({ id: i, ...edge })),
-          });
+        const graph = new Graph({
+          nodes: data.nodes,
+          edges: data.edges.map((edge, i) => ({ id: i, ...edge })),
+        });
 
-          const fruchterman = new FruchtermanLayout({
-            width: 500,
-            height: 500,
-          });
-          const supervisor = new Supervisor(graph, fruchterman, {
-            iterations: 1000,
-          });
+        const fruchterman = new FruchtermanLayout({
+          width: 500,
+          height: 500,
+        });
+        const supervisor = new Supervisor(graph, fruchterman, {
+          iterations: 1000,
+        });
 
-          const nodes = [];
-          const edges = [];
+        const nodes = [];
+        const edges = [];
 
-          const createNodesEdges = (positions) => {
-            positions.edges.forEach(({ source, target }, i) => {
-              const sourceNode = positions.nodes.find(
-                ({ id }) => id === source
-              );
-              const targetNode = positions.nodes.find(
-                ({ id }) => id === target
-              );
-              const line = new Line({
-                style: {
-                  x1: sourceNode.data.x,
-                  y1: sourceNode.data.y,
-                  x2: targetNode.data.x,
-                  y2: targetNode.data.y,
-                  lineWidth: 1,
-                  stroke: "grey",
-                },
-              });
-              canvas.appendChild(line);
-              edges.push(line);
-            });
-
-            positions.nodes.forEach((node, i) => {
-              const circle = new Circle({
-                style: {
-                  cx: node.data.x,
-                  cy: node.data.y,
-                  r: 6,
-                  fill: "#1890FF",
-                  stroke: "#F04864",
-                  lineWidth: 2,
-                  draggable: true,
-                },
-              });
-              canvas.appendChild(circle);
-
-              let shiftX = 0;
-              let shiftY = 0;
-              function moveAt(target, canvasX, canvasY) {
-                graph.mergeNodeData(positions.nodes[i].id, {
-                  x: canvasX - shiftX,
-                  y: canvasY - shiftY,
-                });
-                fruchterman.stop();
-                fruchterman.assign(graph, {
-                  onTick: (positions) => {
-                    updateNodesEdges(positions);
-                  },
-                });
-              }
-
-              circle.addEventListener("dragstart", function (e) {
-                const [x, y] = e.target.getPosition();
-                shiftX = e.canvasX - x;
-                shiftY = e.canvasY - y;
-
-                moveAt(e.target, e.canvasX, e.canvasY);
-              });
-              circle.addEventListener("drag", function (e) {
-                moveAt(e.target, e.canvasX, e.canvasY);
-              });
-              nodes.push(circle);
-            });
-          };
-
-          const updateNodesEdges = (positions) => {
-            positions.edges.forEach(({ source, target }, i) => {
-              const sourceNode = positions.nodes.find(
-                ({ id }) => id === source
-              );
-              const targetNode = positions.nodes.find(
-                ({ id }) => id === target
-              );
-
-              edges[i].attr({
+        const createNodesEdges = (positions) => {
+          positions.edges.forEach(({ source, target }, i) => {
+            const sourceNode = positions.nodes.find(({ id }) => id === source);
+            const targetNode = positions.nodes.find(({ id }) => id === target);
+            const line = new Line({
+              style: {
                 x1: sourceNode.data.x,
                 y1: sourceNode.data.y,
                 x2: targetNode.data.x,
                 y2: targetNode.data.y,
-              });
+                lineWidth: 1,
+                stroke: "grey",
+              },
             });
+            canvas.appendChild(line);
+            edges.push(line);
+          });
 
-            positions.nodes.forEach((node, i) => {
-              nodes[i].attr({
+          positions.nodes.forEach((node, i) => {
+            const circle = new Circle({
+              style: {
                 cx: node.data.x,
                 cy: node.data.y,
-              });
+                r: 6,
+                fill: "#1890FF",
+                stroke: "#F04864",
+                lineWidth: 2,
+                draggable: true,
+              },
             });
-          };
+            canvas.appendChild(circle);
 
-          // Do first-time static layout on worker-side.
-          supervisor.on("layoutend", (positions) => {
-            // Update Graph model.
-            positions.nodes.forEach((node) =>
-              graph.mergeNodeData(node.id, {
-                x: node.data.x,
-                y: node.data.y,
-              })
-            );
+            let shiftX = 0;
+            let shiftY = 0;
+            function moveAt(target, canvasX, canvasY) {
+              graph.mergeNodeData(positions.nodes[i].id, {
+                x: canvasX - shiftX,
+                y: canvasY - shiftY,
+              });
+              fruchterman.stop();
+              fruchterman.assign(graph, {
+                onTick: (positions) => {
+                  updateNodesEdges(positions);
+                },
+              });
+            }
 
-            // Render.
-            createNodesEdges(positions);
+            circle.addEventListener("dragstart", function (e) {
+              const [x, y] = e.target.getPosition();
+              shiftX = e.canvasX - x;
+              shiftY = e.canvasY - y;
+
+              moveAt(e.target, e.canvasX, e.canvasY);
+            });
+            circle.addEventListener("drag", function (e) {
+              moveAt(e.target, e.canvasX, e.canvasY);
+            });
+            nodes.push(circle);
           });
-          supervisor.start();
-        });
+        };
+
+        const updateNodesEdges = (positions) => {
+          positions.edges.forEach(({ source, target }, i) => {
+            const sourceNode = positions.nodes.find(({ id }) => id === source);
+            const targetNode = positions.nodes.find(({ id }) => id === target);
+
+            edges[i].attr({
+              x1: sourceNode.data.x,
+              y1: sourceNode.data.y,
+              x2: targetNode.data.x,
+              y2: targetNode.data.y,
+            });
+          });
+
+          positions.nodes.forEach((node, i) => {
+            nodes[i].attr({
+              cx: node.data.x,
+              cy: node.data.y,
+            });
+          });
+        };
+
+        // Do first-time static layout on worker-side.
+        const positions = await supervisor.execute();
+
+        // Update Graph model.
+        positions.nodes.forEach((node) =>
+          graph.mergeNodeData(node.id, {
+            x: node.data.x,
+            y: node.data.y,
+          })
+        );
+
+        // Render.
+        createNodesEdges(positions);
+      })();
     </script>
   </body>
 </html>

--- a/demo/supervisor.html
+++ b/demo/supervisor.html
@@ -37,7 +37,7 @@
       type="application/javascript"
     ></script>
     <script
-      src="https://unpkg.com/@antv/graphlib@2.0.0-alpha.2"
+      src="https://unpkg.com/@antv/graphlib@2.0.0"
       type="application/javascript"
     ></script>
     <script
@@ -897,38 +897,36 @@
       });
 
       const supervisor = new Supervisor(graph, circular);
-      supervisor.on("layoutend", (positions) => {
-        const { Circle, Canvas } = window.G;
+      const { Circle, Canvas } = window.G;
 
-        // create a renderer
-        const canvasRenderer = new window.G.Canvas2D.Renderer();
+      // create a renderer
+      const canvasRenderer = new window.G.Canvas2D.Renderer();
 
-        // create a canvas
-        const canvas = new Canvas({
-          container: "container",
-          width: 500,
-          height: 500,
-          renderer: canvasRenderer,
-        });
-
-        canvas.addEventListener("ready", () => {
-          positions.nodes.forEach((node) => {
-            const circle = new Circle({
-              style: {
-                cx: node.data.x,
-                cy: node.data.y,
-                r: 10,
-                fill: "#1890FF",
-                stroke: "#F04864",
-                lineWidth: 4,
-              },
-            });
-            canvas.appendChild(circle);
-          });
-        });
+      // create a canvas
+      const canvas = new Canvas({
+        container: "container",
+        width: 500,
+        height: 500,
+        renderer: canvasRenderer,
       });
 
-      supervisor.start();
+      (async () => {
+        await canvas.ready;
+        const positions = await supervisor.execute();
+        positions.nodes.forEach((node) => {
+          const circle = new Circle({
+            style: {
+              cx: node.data.x,
+              cy: node.data.y,
+              r: 10,
+              fill: "#1890FF",
+              stroke: "#F04864",
+              lineWidth: 4,
+            },
+          });
+          canvas.appendChild(circle);
+        });
+      })();
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "@antv/graphlib": "^2.0.0",
     "@babel/core": "*",
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "*",
@@ -61,8 +62,7 @@
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^4.0.3",
-    "@antv/graphlib": "^2.0.0-alpha.1"
+    "typescript": "^4.0.3"
   },
   "release-it": {
     "git": {

--- a/packages/layout-gpu/README.md
+++ b/packages/layout-gpu/README.md
@@ -67,8 +67,6 @@ We provide the following parallelizable layouts:
 - [Fruchterman]()
 - [GForce]()
 
-Since the GPGPU is asynchronous, `onLayoutEnd` callback should be passed in.
-
 ```js
 import { Graph } from "@antv/graphlib";
 import { FruchtermanLayout } from "@antv/layout-gpu";
@@ -76,11 +74,9 @@ import { FruchtermanLayout } from "@antv/layout-gpu";
 const graph = new Graph({ nodes: [], edges: [] });
 
 const fruchtermanLayout = new FruchtermanLayout({
-  onLayoutEnd: (positions) => {
-    // render nodes & edges
-  },
+  center: [200, 200],
 });
-fruchtermanLayout.assign(graph);
+const positions = await fruchtermanLayout.execute(graph);
 ```
 
 ### Fruchterman

--- a/packages/layout-gpu/README.md
+++ b/packages/layout-gpu/README.md
@@ -22,16 +22,14 @@ import { FruchtermanLayout } from "@antv/layout-gpu";
 
 const graph = new Graph({ nodes: [], edges: [] });
 
-const fruchtermanLayout = new FruchtermanLayout({
-  onLayoutEnd: (positions) => {
-    // render nodes & edges
-  },
-});
+const fruchtermanLayout = new FruchtermanLayout();
 
-// Return positions of nodes & edges.
-const positions = fruchtermanLayout.execute(graph);
-// Or to directly assign the positions to the nodes:
-circularLayout.assign(graph);
+(async () => {
+  // Return positions of nodes & edges.
+  const positions = await fruchtermanLayout.execute(graph);
+  // Or to directly assign the positions to the nodes:
+  await circularLayout.assign(graph);
+})();
 ```
 
 ### UMD

--- a/packages/layout-gpu/package.json
+++ b/packages/layout-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout-gpu",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "graph layout algorithm implemented with GPGPU",
   "main": "dist/index.min.js",
   "module": "esm/index.esm.js",

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -28,11 +28,13 @@ const graph = new Graph({ nodes: [], edges: [] });
 
 const circularLayout = new CircularLayout({ radius: 10 });
 
-// 1. Return positions of nodes & edges.
-const positions = circularLayout.execute(graph);
+(async () => {
+  // 1. Return positions of nodes & edges.
+  const positions = await circularLayout.execute(graph);
 
-// 2. To directly assign the positions to the nodes:
-circularLayout.assign(graph);
+  // 2. To directly assign the positions to the nodes:
+  await circularLayout.assign(graph);
+})();
 ```
 
 ### UMD
@@ -284,11 +286,14 @@ const graph = new Graph();
 const layout = new CircularLayout();
 
 const supervisor = new Supervisor(graph, layout);
-supervisor.on("layoutend", (positions) => {});
-supervisor.start();
+const positions = await supervisor.execute();
 ```
 
 [Online Demo](https://observablehq.com/d/2db6b0cc5e97d8d6#cell-199)
+
+- `execute` Call `execute` on the selected layout algorithm. This is an async method.
+- `stop` Call `stop` on the selected layout algorithm.
+- `kill` Terminate the WebWorker.
 
 ## License
 

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.16",
   "description": "graph layout algorithm",
   "main": "dist/index.min.js",
   "module": "esm/index.esm.js",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -21,7 +21,7 @@
     "antv"
   ],
   "dependencies": {
-    "@antv/graphlib": "^2.0.0-alpha.3",
+    "@antv/graphlib": "^2.0.0",
     "@antv/util": "^3.0.0",
     "@naoak/workerize-transferable": "^0.1.0",
     "d3-force": "^3.0.0",

--- a/packages/layout/src/concentric.ts
+++ b/packages/layout/src/concentric.ts
@@ -30,14 +30,14 @@ const DEFAULTS_LAYOUT_OPTIONS: Partial<ConcentricLayoutOptions> = {
  * @example
  * // Assign layout options when initialization.
  * const layout = new ConcentricLayout({ nodeSpacing: 10 });
- * const positions = layout.execute(graph); // { nodes: [], edges: [] }
+ * const positions = await layout.execute(graph); // { nodes: [], edges: [] }
  *
  * // Or use different options later.
  * const layout = new ConcentricLayout({ nodeSpacing: 10});
- * const positions = layout.execute(graph, { nodeSpacing: 10 }); // { nodes: [], edges: [] }
+ * const positions = await layout.execute(graph, { nodeSpacing: 10 }); // { nodes: [], edges: [] }
  *
  * // If you want to assign the positions directly to the nodes, use assign method.
- * layout.assign(graph, { nodeSpacing: 10 });
+ * await layout.assign(graph, { nodeSpacing: 10 });
  */
 export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
   id = "concentric";
@@ -54,21 +54,31 @@ export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
   /**
    * Return the positions of nodes and edges(if needed).
    */
-  execute(graph: Graph, options?: ConcentricLayoutOptions): LayoutMapping {
-    return this.genericConcentricLayout(false, graph, options) as LayoutMapping;
+  async execute(graph: Graph, options?: ConcentricLayoutOptions) {
+    return this.genericConcentricLayout(false, graph, options);
   }
   /**
    * To directly assign the positions to the nodes.
    */
-  assign(graph: Graph, options?: ConcentricLayoutOptions) {
+  async assign(graph: Graph, options?: ConcentricLayoutOptions) {
     this.genericConcentricLayout(true, graph, options);
   }
 
-  private genericConcentricLayout(
+  private async genericConcentricLayout(
+    assign: false,
+    graph: Graph,
+    options?: ConcentricLayoutOptions
+  ): Promise<LayoutMapping>;
+  private async genericConcentricLayout(
+    assign: true,
+    graph: Graph,
+    options?: ConcentricLayoutOptions
+  ): Promise<void>;
+  private async genericConcentricLayout(
     assign: boolean,
     graph: Graph,
     options?: ConcentricLayoutOptions
-  ): LayoutMapping | void {
+  ): Promise<LayoutMapping | void> {
     const mergedOptions = { ...this.options, ...options };
     const {
       center: propsCenter,
@@ -83,7 +93,6 @@ export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
       startAngle = (3 / 2) * Math.PI,
       nodeSize,
       nodeSpacing,
-      onLayoutEnd,
     } = mergedOptions;
 
     let nodes = graph.getAllNodes();
@@ -102,7 +111,7 @@ export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
     ) as PointTuple;
 
     if (!nodes?.length || nodes.length === 1) {
-      return handleSingleNodeGraph(graph, assign, center, onLayoutEnd);
+      return handleSingleNodeGraph(graph, assign, center);
     }
 
     const layoutNodes: OutNode[] = [];
@@ -279,8 +288,6 @@ export class ConcentricLayout implements Layout<ConcentricLayoutOptions> {
       nodes: layoutNodes,
       edges,
     };
-
-    onLayoutEnd?.(result);
 
     return result;
   }

--- a/packages/layout/src/radial/index.ts
+++ b/packages/layout/src/radial/index.ts
@@ -41,14 +41,14 @@ const DEFAULTS_LAYOUT_OPTIONS: Partial<RadialLayoutOptions> = {
  * @example
  * // Assign layout options when initialization.
  * const layout = new RadialLayout({ focusNode: 'node0' });
- * const positions = layout.execute(graph); // { nodes: [], edges: [] }
+ * const positions = await layout.execute(graph); // { nodes: [], edges: [] }
  *
  * // Or use different options later.
  * const layout = new RadialLayout({ focusNode: 'node0' });
- * const positions = layout.execute(graph, { focusNode: 'node0' }); // { nodes: [], edges: [] }
+ * const positions = await layout.execute(graph, { focusNode: 'node0' }); // { nodes: [], edges: [] }
  *
  * // If you want to assign the positions directly to the nodes, use assign method.
- * layout.assign(graph, { focusNode: 'node0' });
+ * await layout.assign(graph, { focusNode: 'node0' });
  */
 export class RadialLayout implements Layout<RadialLayoutOptions> {
   id = "radial";
@@ -63,21 +63,31 @@ export class RadialLayout implements Layout<RadialLayoutOptions> {
   /**
    * Return the positions of nodes and edges(if needed).
    */
-  execute(graph: Graph, options?: RadialLayoutOptions): LayoutMapping {
-    return this.genericRadialLayout(false, graph, options) as LayoutMapping;
+  async execute(graph: Graph, options?: RadialLayoutOptions) {
+    return this.genericRadialLayout(false, graph, options);
   }
   /**
    * To directly assign the positions to the nodes.
    */
-  assign(graph: Graph, options?: RadialLayoutOptions) {
+  async assign(graph: Graph, options?: RadialLayoutOptions) {
     this.genericRadialLayout(true, graph, options);
   }
 
-  private genericRadialLayout(
+  private async genericRadialLayout(
+    assign: false,
+    graph: Graph,
+    options?: RadialLayoutOptions
+  ): Promise<LayoutMapping>;
+  private async genericRadialLayout(
+    assign: true,
+    graph: Graph,
+    options?: RadialLayoutOptions
+  ): Promise<void>;
+  private async genericRadialLayout(
     assign: boolean,
     graph: Graph,
     options?: RadialLayoutOptions
-  ): LayoutMapping | void {
+  ): Promise<LayoutMapping | void> {
     const mergedOptions = { ...this.options, ...options };
     const {
       width: propsWidth,
@@ -94,7 +104,6 @@ export class RadialLayout implements Layout<RadialLayoutOptions> {
       linkDistance = 50,
       sortStrength = 10,
       maxIteration = 1000,
-      onLayoutEnd,
     } = mergedOptions;
 
     let nodes = graph.getAllNodes();
@@ -113,7 +122,7 @@ export class RadialLayout implements Layout<RadialLayoutOptions> {
     ) as PointTuple;
 
     if (!nodes?.length || nodes.length === 1) {
-      return handleSingleNodeGraph(graph, assign, center, onLayoutEnd);
+      return handleSingleNodeGraph(graph, assign, center);
     }
 
     let focusNode = nodes[0];
@@ -231,7 +240,6 @@ export class RadialLayout implements Layout<RadialLayoutOptions> {
       nodes: layoutNodes,
       edges,
     };
-    onLayoutEnd?.(result);
 
     return result;
   }

--- a/packages/layout/src/random.ts
+++ b/packages/layout/src/random.ts
@@ -19,14 +19,14 @@ const DEFAULTS_LAYOUT_OPTIONS: Partial<RandomLayoutOptions> = {
  * @example
  * // Assign layout options when initialization.
  * const layout = new RandomLayout({ center: [100, 100] });
- * const positions = layout.execute(graph); // { nodes: [], edges: [] }
+ * const positions = await layout.execute(graph); // { nodes: [], edges: [] }
  *
  * // Or use different options later.
  * const layout = new RandomLayout({ center: [100, 100] });
- * const positions = layout.execute(graph, { center: [100, 100] }); // { nodes: [], edges: [] }
+ * const positions = await layout.execute(graph, { center: [100, 100] }); // { nodes: [], edges: [] }
  *
  * // If you want to assign the positions directly to the nodes, use assign method.
- * layout.assign(graph, { center: [100, 100] });
+ * await layout.assign(graph, { center: [100, 100] });
  */
 export class RandomLayout implements Layout<RandomLayoutOptions> {
   id = "random";
@@ -41,27 +41,36 @@ export class RandomLayout implements Layout<RandomLayoutOptions> {
   /**
    * Return the positions of nodes and edges(if needed).
    */
-  execute(graph: Graph, options?: RandomLayoutOptions): LayoutMapping {
-    return this.genericRandomLayout(false, graph, options) as LayoutMapping;
+  async execute(graph: Graph, options?: RandomLayoutOptions) {
+    return this.genericRandomLayout(false, graph, options);
   }
   /**
    * To directly assign the positions to the nodes.
    */
-  assign(graph: Graph, options?: RandomLayoutOptions) {
+  async assign(graph: Graph, options?: RandomLayoutOptions) {
     this.genericRandomLayout(true, graph, options);
   }
 
-  private genericRandomLayout(
+  private async genericRandomLayout(
+    assign: false,
+    graph: Graph,
+    options?: RandomLayoutOptions
+  ): Promise<LayoutMapping>;
+  private async genericRandomLayout(
+    assign: true,
+    graph: Graph,
+    options?: RandomLayoutOptions
+  ): Promise<void>;
+  private async genericRandomLayout(
     assign: boolean,
     graph: Graph,
     options?: RandomLayoutOptions
-  ): LayoutMapping | void {
+  ): Promise<LayoutMapping | void> {
     const mergedOptions = { ...this.options, ...options };
     const {
       center: propsCenter,
       width: propsWidth,
       height: propsHeight,
-      onLayoutEnd,
     } = mergedOptions;
 
     let nodes = graph.getAllNodes();
@@ -104,8 +113,6 @@ export class RandomLayout implements Layout<RandomLayoutOptions> {
       nodes: layoutNodes,
       edges: graph.getAllEdges(),
     };
-
-    onLayoutEnd?.(result);
 
     return result;
   }

--- a/packages/layout/src/types.ts
+++ b/packages/layout/src/types.ts
@@ -7,7 +7,6 @@ import {
 } from "@antv/graphlib";
 
 export interface NodeData extends PlainObject {
-  visible?: boolean;
   size?: number | number[];
   bboxSize?: number[];
 }
@@ -18,7 +17,6 @@ export interface OutNodeData extends NodeData {
 }
 
 export interface EdgeData extends PlainObject {
-  visible?: boolean;
   // temp edges e.g. the edge generated for releated collapsed combo
   virtual?: boolean;
 }
@@ -53,11 +51,11 @@ export interface Layout<LayoutOptions> {
   /**
    * To directly assign the positions to the nodes.
    */
-  assign(graph: Graph, options?: LayoutOptions): void;
+  assign(graph: Graph, options?: LayoutOptions): Promise<void>;
   /**
    * Return the positions of nodes and edges(if needed).
    */
-  execute(graph: Graph, options?: LayoutOptions): LayoutMapping;
+  execute(graph: Graph, options?: LayoutOptions): Promise<LayoutMapping>;
   /**
    * Layout options, can be changed in runtime.
    */
@@ -71,7 +69,7 @@ export interface Layout<LayoutOptions> {
 export function isLayoutWithIterations(
   layout: any
 ): layout is LayoutWithIterations<any> {
-  return !!layout.tick && !!layout.stop && !!layout.restart;
+  return !!layout.tick && !!layout.stop;
 }
 
 export interface LayoutWithIterations<LayoutOptions>
@@ -82,12 +80,6 @@ export interface LayoutWithIterations<LayoutOptions>
    * @see https://github.com/d3/d3-force#simulation_stop
    */
   stop: () => void;
-
-  /**
-   * Restarts the simulation’s internal timer and returns the simulation.
-   * @see https://github.com/d3/d3-force#simulation_restart
-   */
-  restart: () => void;
 
   /**
    * Manually steps the simulation by the specified number of iterations.
@@ -101,7 +93,7 @@ export interface LayoutConstructor<LayoutOptions> {
 }
 
 export interface LayoutSupervisor {
-  start(): void;
+  execute(): Promise<LayoutMapping>;
   stop(): void;
   kill(): void;
   isRunning(): boolean;

--- a/packages/layout/src/util/common.ts
+++ b/packages/layout/src/util/common.ts
@@ -1,4 +1,4 @@
-import { PointTuple, LayoutMapping, Graph } from "../types";
+import { PointTuple, Graph } from "../types";
 
 /**
  * Assign or only return the result for the graph who has no nodes or only one node.
@@ -6,19 +6,17 @@ import { PointTuple, LayoutMapping, Graph } from "../types";
  * @param assign whether assign result to original graph
  * @param center the layout center
  * @param onLayoutEnd callback for layout end
- * @returns 
+ * @returns
  */
 export const handleSingleNodeGraph = (
   graph: Graph,
   assign: boolean,
-  center: PointTuple,
-  onLayoutEnd?: (data: LayoutMapping) => void
+  center: PointTuple
 ) => {
   const nodes = graph.getAllNodes();
   const edges = graph.getAllEdges();
   if (!nodes?.length) {
     const result = { nodes: [], edges };
-    onLayoutEnd?.(result);
     return result;
   }
   if (nodes.length === 1) {
@@ -36,12 +34,11 @@ export const handleSingleNodeGraph = (
             ...nodes[0].data,
             x: center[0],
             y: center[1],
-          }
-        }
+          },
+        },
       ],
       edges,
     };
-    onLayoutEnd?.(result);
     return result;
   }
 };

--- a/packages/layout/src/worker.ts
+++ b/packages/layout/src/worker.ts
@@ -2,12 +2,7 @@ import { Graph } from "@antv/graphlib";
 // import { setupTransferableMethodsOnWorker } from "@naoak/workerize-transferable";
 import { registry } from "./registry";
 import type { Payload } from "./supervisor";
-import {
-  LayoutMapping,
-  Layout,
-  LayoutWithIterations,
-  isLayoutWithIterations,
-} from "./types";
+import { Layout, LayoutWithIterations, isLayoutWithIterations } from "./types";
 
 // @see https://www.npmjs.com/package/@naoak/workerize-transferable
 // setupTransferableMethodsOnWorker({
@@ -58,18 +53,10 @@ export async function calculateLayout(
     throw new Error(`Unknown layout id: ${id}`);
   }
 
-  return new Promise((resolve) => {
-    // Do calculation.
-    currentLayout.assign(graph, {
-      onLayoutEnd: (positions: LayoutMapping) => {
-        resolve([positions, transferables]);
-      },
-    });
-
-    // Do static layout.
-    if (isLayoutWithIterations(currentLayout)) {
-      currentLayout.stop();
-      currentLayout.tick(iterations);
-    }
-  });
+  let positions = await currentLayout.execute(graph);
+  if (isLayoutWithIterations(currentLayout)) {
+    currentLayout.stop();
+    positions = currentLayout.tick(iterations);
+  }
+  return [positions, transferables];
 }


### PR DESCRIPTION
考虑到 GPU 和 WebWorker 中运行布局算法，统一所有同步/异步算法到异步方式，同时取消 `onLayoutEnd` 回调，以 `execute` 为例（`assign` 同理）：

```js
// Before
const positions = force.execute(graph); // 同步算法例如 circular
force.execute(graph, { // 异步算法例如 force
  onLayoutEnd: (positions) => {}
});

// After
const positions = await force.execute(graph);
```

Supervisor API 和算法保持统一，调用异步方法 `execute` 即可在 WebWorker 中运行：

```js
// Before
const force = Force({ // 异步算法例如 force
  onLayoutEnd: (positions) => {}
});
const supervisor = new Supervisor(graph, force);
await supervisor.start();

// After
const positions = await supervisor.execute();
```

已修改 [OB 上的示例](https://observablehq.com/d/2db6b0cc5e97d8d6) 和 API 说明文档