### PR TITLE
移除多余的 onLayoutEnd 选项

### DIFF
--- a/__tests__/unit/circular.test.ts
+++ b/__tests__/unit/circular.test.ts
@@ -20,10 +20,6 @@ describe("CircularLayout", () => {
     await circular.assign(graph);
     expect(graph.getAllNodes()).toEqual([]);
     expect(graph.getAllEdges()).toEqual([]);
-
-    // const mockOnLayoutEnd = jest.fn();
-    // circular.execute(graph, { onLayoutEnd: mockOnLayoutEnd });
-    // expect(mockOnLayoutEnd).toHaveBeenCalledTimes(1);
   });
 
   it("should layout quickly when there's only one node in graph.", async () => {

--- a/__tests__/unit/fruchterman.test.ts
+++ b/__tests__/unit/fruchterman.test.ts
@@ -117,7 +117,7 @@ describe("FruchtermanLayout", () => {
     expect(cClusterDist < acClusterDist).toBe(true);
   });
 
-  it("should do fruchterman layout with onTick and onLayoutEnd.", async () => {
+  it("should do fruchterman layout with onTick.", async () => {
     const graph = new Graph<any, any>({
       nodes: [...data.nodes],
       edges: [...data.edges],

--- a/demo/gforce.gpu.html
+++ b/demo/gforce.gpu.html
@@ -912,7 +912,7 @@
         edges: data.edges,
       });
 
-      const fruchterman = new GForceLayout({
+      const gforce = new GForceLayout({
         width: 500,
         height: 500,
         center: [250, 250],
@@ -955,12 +955,10 @@
         });
       };
 
-      fruchterman.assign(graph, {
-        onLayoutEnd: (positions) => {
-          console.log(positions);
-          createNodesEdges(positions);
-        },
-      });
+      (async () => {
+        const positions = await gforce.execute(graph);
+        createNodesEdges(positions);
+      })();
     </script>
   </body>
 </html>

--- a/packages/layout-gpu/README.md
+++ b/packages/layout-gpu/README.md
@@ -14,7 +14,7 @@ $ npm install @antv/layout-gpu --save
 $ yarn add @antv/layout-gpu
 ```
 
-Choose a layout algorithm from `@antv/layout-gpu` then. Since the GPGPU is asynchronous, `onLayoutEnd` callback should be passed in.
+Choose a layout algorithm from `@antv/layout-gpu` then.
 
 ```ts
 import { Graph } from "@antv/graphlib";

--- a/packages/layout-gpu/src/gforce.ts
+++ b/packages/layout-gpu/src/gforce.ts
@@ -53,11 +53,11 @@ interface FormattedOptions extends ForceLayoutOptions {
  *
  * @example
  * // Assign layout options when initialization.
- * const layout = new GForceLayout({ center: [100, 100], onLayoutEnd: (positions) => {} });
+ * const layout = new GForceLayout({ center: [100, 100] });
  * const positions = await layout.execute(graph); // { nodes: [], edges: [] }
  *
  * // Or use different options later.
- * const layout = new GForceLayout({ center: [100, 100], onLayoutEnd: (positions) => {} });
+ * const layout = new GForceLayout({ center: [100, 100] });
  * const positions = await layout.execute(graph, { center: [100, 100] }); // { nodes: [], edges: [] }
  *
  * // If you want to assign the positions directly to the nodes, use assign method.

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/layout",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "description": "graph layout algorithm",
   "main": "dist/index.min.js",
   "module": "esm/index.esm.js",

--- a/packages/layout/src/d3Force/index.ts
+++ b/packages/layout/src/d3Force/index.ts
@@ -97,7 +97,6 @@ export class D3ForceLayout
 
   /**
    * Manually steps the simulation by the specified number of iterations.
-   * When finished it will trigger `onLayoutEnd` callback.
    * @see https://github.com/d3/d3-force#simulation_tick
    */
   tick(iterations = 1) {

--- a/packages/layout/src/d3Force/index.ts
+++ b/packages/layout/src/d3Force/index.ts
@@ -305,27 +305,27 @@ export class D3ForceLayout
           });
         }
         forceSimulation.alpha(alpha).restart();
+
+        // since d3 writes x and y as node's first level properties, format them into data
+        const outNodes = formatOutNodes(layoutNodes);
+        const outEdges = formatOutEdges(layoutEdges);
+
+        if (assign) {
+          outNodes.forEach((node) =>
+            graph.mergeNodeData(node.id, {
+              x: node.data.x,
+              y: node.data.y,
+            })
+          );
+        }
+
+        resolve({
+          nodes: outNodes,
+          edges: outEdges,
+        });
       }
 
       this.forceSimulation = forceSimulation;
-
-      // since d3 writes x and y as node's first level properties, format them into data
-      const outNodes = formatOutNodes(layoutNodes);
-      const outEdges = formatOutEdges(layoutEdges);
-
-      if (assign) {
-        outNodes.forEach((node) =>
-          graph.mergeNodeData(node.id, {
-            x: node.data.x,
-            y: node.data.y,
-          })
-        );
-      }
-
-      resolve({
-        nodes: outNodes,
-        edges: outEdges,
-      });
     });
   }
 

--- a/packages/layout/src/fruchterman.ts
+++ b/packages/layout/src/fruchterman.ts
@@ -116,7 +116,6 @@ export class FruchtermanLayout
 
   /**
    * Manually steps the simulation by the specified number of iterations.
-   * When finished it will trigger `onLayoutEnd` callback.
    * @see https://github.com/d3/d3-force#simulation_tick
    */
   tick(iterations = this.options.maxIteration || 1) {
@@ -140,10 +139,6 @@ export class FruchtermanLayout
           y: node.data.y,
         })
       );
-    }
-
-    if (this.lastOptions.onLayoutEnd) {
-      this.lastOptions.onLayoutEnd(result);
     }
 
     return result;

--- a/packages/layout/src/types.ts
+++ b/packages/layout/src/types.ts
@@ -99,12 +99,7 @@ export interface LayoutSupervisor {
   isRunning(): boolean;
 }
 
-// most layout options extends CommonOptions
-interface CommonOptions {
-  onLayoutEnd?: (data: LayoutMapping) => void;
-}
-
-export interface CircularLayoutOptions extends CommonOptions {
+export interface CircularLayoutOptions {
   center?: PointTuple;
   width?: number;
   height?: number;
@@ -121,7 +116,7 @@ export interface CircularLayoutOptions extends CommonOptions {
   nodeSize?: number | number[];
 }
 
-export interface GridLayoutOptions extends CommonOptions {
+export interface GridLayoutOptions {
   width?: number;
   height?: number;
   begin?: PointTuple;
@@ -136,18 +131,18 @@ export interface GridLayoutOptions extends CommonOptions {
   nodeSpacing?: ((node?: Node) => number) | number;
 }
 
-export interface RandomLayoutOptions extends CommonOptions {
+export interface RandomLayoutOptions {
   center?: PointTuple;
   width?: number;
   height?: number;
 }
 
-export interface MDSLayoutOptions extends CommonOptions {
+export interface MDSLayoutOptions {
   center?: PointTuple;
   linkDistance?: number;
 }
 
-export interface ConcentricLayoutOptions extends CommonOptions {
+export interface ConcentricLayoutOptions {
   center?: PointTuple;
   preventOverlap?: boolean;
   nodeSize?: number | PointTuple;
@@ -162,7 +157,7 @@ export interface ConcentricLayoutOptions extends CommonOptions {
   nodeSpacing?: number | number[] | ((node?: Node) => number);
 }
 
-export interface RadialLayoutOptions extends CommonOptions {
+export interface RadialLayoutOptions {
   center?: PointTuple;
   width?: number;
   height?: number;
@@ -179,7 +174,7 @@ export interface RadialLayoutOptions extends CommonOptions {
   sortStrength?: number;
 }
 
-export interface DagreLayoutOptions extends CommonOptions {
+export interface DagreLayoutOptions {
   rankdir?: "TB" | "BT" | "LR" | "RL";
   align?: "UL" | "UR" | "DL" | "DR";
   begin?: PointTuple;
@@ -200,7 +195,7 @@ export interface DagreLayoutOptions extends CommonOptions {
   ranksepFunc?: (d?: Node) => number;
 }
 
-export interface D3ForceLayoutOptions extends CommonOptions {
+export interface D3ForceLayoutOptions {
   center?: PointTuple;
   linkDistance?: number | ((edge?: Edge) => number);
   edgeStrength?: number | ((edge?: Edge) => number);
@@ -242,7 +237,7 @@ export interface CentripetalOptions {
     centerStrength?: number;
   };
 }
-export interface ForceLayoutOptions extends CommonOptions {
+export interface ForceLayoutOptions {
   center?: PointTuple;
   width?: number;
   height?: number;
@@ -278,7 +273,7 @@ export interface ForceLayoutOptions extends CommonOptions {
   }) => void;
 }
 
-export interface ForceAtlas2LayoutOptions extends CommonOptions {
+export interface ForceAtlas2LayoutOptions {
   center?: PointTuple;
   width?: number;
   height?: number;
@@ -296,7 +291,7 @@ export interface ForceAtlas2LayoutOptions extends CommonOptions {
   nodeSize?: number | number[] | ((node?: Node) => number);
   onTick?: (data: LayoutMapping) => void;
 }
-export interface FruchtermanLayoutOptions extends CommonOptions {
+export interface FruchtermanLayoutOptions {
   center?: PointTuple;
   maxIteration?: number;
   width?: number;

--- a/packages/layout/src/util/common.ts
+++ b/packages/layout/src/util/common.ts
@@ -5,7 +5,6 @@ import { PointTuple, Graph } from "../types";
  * @param graph original graph
  * @param assign whether assign result to original graph
  * @param center the layout center
- * @param onLayoutEnd callback for layout end
  * @returns
  */
 export const handleSingleNodeGraph = (


### PR DESCRIPTION
#142 由于改成了异步方式，不再需要 `onLayoutEnd` 选项了