### PR TITLE
fix: large args in dagre layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@antv/g-webgpu": "0.7.2",
     "@antv/graphlib": "^1.0.0",
+    "@antv/util": "^3.3.2",
     "d3-force": "^2.1.1",
     "d3-quadtree": "^2.0.0",
     "dagre-compound": "^0.0.11",
@@ -58,9 +59,9 @@
     "@babel/preset-env": "*",
     "@babel/preset-typescript": "*",
     "@types/d3-force": "^2.1.0",
+    "@types/d3-quadtree": "^2.0.0",
     "@types/graphlib": "^2.1.8",
     "@types/jest": "^25.2.1",
-    "@types/d3-quadtree": "^2.0.0",
     "babel-jest": "28.1.3",
     "babel-loader": "^8.2.2",
     "eslint": "^7.11.0",

--- a/src/layout/dagre/src/order/init-order.ts
+++ b/src/layout/dagre/src/order/init-order.ts
@@ -1,5 +1,5 @@
 import { Graph } from "../../graph";
-import { max } from './math';
+import { max } from '@antv/util';
 
 /*
  * Assigns an initial order value for each node by performing a DFS search

--- a/src/layout/dagre/src/order/init-order.ts
+++ b/src/layout/dagre/src/order/init-order.ts
@@ -18,12 +18,11 @@ const initOrder = (g: Graph) => {
     return !g.children(v)?.length;
   });
   const nodeRanks = simpleNodes.map((v) => (g.node(v)!.rank as number));
-  const maxRank = max(nodeRanks);
+  const maxRank = max(nodeRanks)!;
   const layers: string[][] = [];
-  if (typeof maxRank === 'number')
-    for (let i = 0; i < maxRank + 1; i++) {
-      layers.push([]);
-    }
+  for (let i = 0; i < maxRank + 1; i++) {
+    layers.push([]);
+  }
 
   const dfs = (v: string) => {
     if (visited.hasOwnProperty(v)) return;

--- a/src/layout/dagre/src/order/init-order.ts
+++ b/src/layout/dagre/src/order/init-order.ts
@@ -1,4 +1,5 @@
 import { Graph } from "../../graph";
+import { max } from './math';
 
 /*
  * Assigns an initial order value for each node by performing a DFS search
@@ -17,11 +18,12 @@ const initOrder = (g: Graph) => {
     return !g.children(v)?.length;
   });
   const nodeRanks = simpleNodes.map((v) => (g.node(v)!.rank as number));
-  const maxRank = Math.max(...nodeRanks);
+  const maxRank = max(nodeRanks);
   const layers: string[][] = [];
-  for (let i = 0; i < maxRank + 1; i++) {
-    layers.push([]);
-  }
+  if (typeof maxRank === 'number')
+    for (let i = 0; i < maxRank + 1; i++) {
+      layers.push([]);
+    }
 
   const dfs = (v: string) => {
     if (visited.hasOwnProperty(v)) return;

--- a/src/layout/dagre/src/order/math.ts
+++ b/src/layout/dagre/src/order/math.ts
@@ -1,0 +1,7 @@
+export function max(nodeRanks: number[]) {
+    return nodeRanks.length > 0 ? nodeRanks.reduce((max, cur) => {return cur > max ? cur : max;}, nodeRanks[0]) : undefined;
+}
+
+export function min(nodeRanks: number[]) {
+    return nodeRanks.length > 0 ? nodeRanks.reduce((min, cur) => {return cur < min ? cur : min;}, nodeRanks[0]) : undefined;
+}

--- a/src/layout/dagre/src/order/math.ts
+++ b/src/layout/dagre/src/order/math.ts
@@ -1,7 +1,0 @@
-export function max(nodeRanks: number[]) {
-    return nodeRanks.length > 0 ? nodeRanks.reduce((max, cur) => {return cur > max ? cur : max;}, nodeRanks[0]) : undefined;
-}
-
-export function min(nodeRanks: number[]) {
-    return nodeRanks.length > 0 ? nodeRanks.reduce((min, cur) => {return cur < min ? cur : min;}, nodeRanks[0]) : undefined;
-}

--- a/src/layout/dagre/src/position/bk.ts
+++ b/src/layout/dagre/src/position/bk.ts
@@ -373,8 +373,8 @@ export function alignCoordinates(
   alignTo: Record<string, number>
 ) {
   const alignToVals = Object.values(alignTo);
-  const alignToMin = Number(min(alignToVals));
-  const alignToMax = Number(max(alignToVals));
+  const alignToMin = min(alignToVals)!;
+  const alignToMax = max(alignToVals)!;
 
   ["u", "d"].forEach((vert) => {
     ["l", "r"].forEach((horiz) => {
@@ -386,8 +386,8 @@ export function alignCoordinates(
       const xsVals = Object.values(xs);
       delta =
         horiz === "l"
-          ? alignToMin - Number(min(xsVals))
-          : alignToMax - Number(max(xsVals));
+          ? alignToMin - min(xsVals)!
+          : alignToMax - max(xsVals)!;
 
       if (delta) {
         xss[alignment] = {};

--- a/src/layout/dagre/src/position/bk.ts
+++ b/src/layout/dagre/src/position/bk.ts
@@ -4,6 +4,7 @@
  */
 import { Graph as RawGraph } from "@antv/graphlib";
 import { Graph } from "../../graph";
+import { max, min } from '../order/math';
 import { buildLayerMatrix, minBy } from "../util";
 
 class BlockGraph extends RawGraph<string, string, number> {}
@@ -86,8 +87,10 @@ export const findType2Conflicts = (g: Graph, layering?: string[][]) => {
     for (let i = southPos; i < southEnd; i++) {
       v = south[i];
       if (g.node(v)?.dummy) {
+        // console.log('g.predecessors(v)', g.predecessors(v), v, g, g.node(v));
         g.predecessors(v)?.forEach((u) => {
           const uNode = g.node(u)!;
+          // console.log('u, v', u, v);
           if (
             uNode.dummy &&
             ((uNode.order as number) < prevNorthBorder ||
@@ -146,6 +149,7 @@ export const findType2Conflicts = (g: Graph, layering?: string[][]) => {
   if (layering?.length) {
     layering.reduce(visitLayer);
   }
+  // console.log('conflicts', conflicts)
   return conflicts;
 };
 
@@ -371,10 +375,9 @@ export function alignCoordinates(
   xss: Record<string, Record<string, number>>,
   alignTo: Record<string, number>
 ) {
-  // @ts-ignore
-  const alignToVals = Object.values(alignTo) as number[];
-  const alignToMin = Math.min(...alignToVals);
-  const alignToMax = Math.max(...alignToVals);
+  const alignToVals = Object.values(alignTo);
+  const alignToMin = Number(min(alignToVals));
+  const alignToMax = Number(max(alignToVals));
 
   ["u", "d"].forEach((vert) => {
     ["l", "r"].forEach((horiz) => {
@@ -383,11 +386,11 @@ export function alignCoordinates(
       let delta: number;
       if (xs === alignTo) return;
 
-      const xsVals = Object.values(xs) as number[];
+      const xsVals = Object.values(xs);
       delta =
         horiz === "l"
-          ? alignToMin - Math.min(...xsVals)
-          : alignToMax - Math.max(...xsVals);
+          ? alignToMin - Number(min(xsVals))
+          : alignToMax - Number(max(xsVals));
 
       if (delta) {
         xss[alignment] = {};

--- a/src/layout/dagre/src/position/bk.ts
+++ b/src/layout/dagre/src/position/bk.ts
@@ -87,10 +87,8 @@ export const findType2Conflicts = (g: Graph, layering?: string[][]) => {
     for (let i = southPos; i < southEnd; i++) {
       v = south[i];
       if (g.node(v)?.dummy) {
-        // console.log('g.predecessors(v)', g.predecessors(v), v, g, g.node(v));
         g.predecessors(v)?.forEach((u) => {
           const uNode = g.node(u)!;
-          // console.log('u, v', u, v);
           if (
             uNode.dummy &&
             ((uNode.order as number) < prevNorthBorder ||
@@ -149,7 +147,6 @@ export const findType2Conflicts = (g: Graph, layering?: string[][]) => {
   if (layering?.length) {
     layering.reduce(visitLayer);
   }
-  // console.log('conflicts', conflicts)
   return conflicts;
 };
 

--- a/src/layout/dagre/src/position/bk.ts
+++ b/src/layout/dagre/src/position/bk.ts
@@ -4,7 +4,7 @@
  */
 import { Graph as RawGraph } from "@antv/graphlib";
 import { Graph } from "../../graph";
-import { max, min } from '../order/math';
+import { max, min } from '@antv/util';
 import { buildLayerMatrix, minBy } from "../util";
 
 class BlockGraph extends RawGraph<string, string, number> {}


### PR DESCRIPTION
**【背景】**

dagre数据量较大时，```Math.max/min```的arguments过长，有导致栈溢出的风险，导致布局失败；

**【解决方案】**

使用```@antv/util```的```max/min```函数替代```Math.max/min```，但需要引入@antv/util(看起来支持treeshaking)；