### PR TITLE
fix: add distance threshold mode to break iterations early

### DIFF
--- a/benchmarks/forceatlas2.test.js
+++ b/benchmarks/forceatlas2.test.js
@@ -8,6 +8,7 @@ const ITERATIONS = 100;
 /**
  * Graphology
  */
+var AntvGraph = require("@antv/graphlib");
 var Graph = require("graphology");
 var graphologyLayout = require("graphology-layout-forceatlas2");
 var randomClusters = require("graphology-generators/random/clusters");

--- a/packages/layout-rust/src/forces/gravity.rs
+++ b/packages/layout-rust/src/forces/gravity.rs
@@ -11,9 +11,9 @@ pub fn apply_gravity_force2<T: Coord + std::fmt::Debug>(layout: &mut Layout<T>) 
         layout.speeds.iter_mut()
     ) {
 
-        for ((i, speed), pos) in speed.iter_mut().enumerate().zip(pos.iter()) {
+        for ((index, speed), pos) in speed.iter_mut().enumerate().zip(pos.iter()) {
             unsafe {
-                *speed -= gf.clone() * (pos.clone() - center.get_unchecked(i).clone()) / mass.clone();    
+                *speed -= gf.clone() * (pos.clone() - center.get_unchecked(index).clone()) / mass.clone();    
             }
         }
     }
@@ -22,7 +22,7 @@ pub fn apply_gravity_force2<T: Coord + std::fmt::Debug>(layout: &mut Layout<T>) 
 pub fn apply_gravity_fruchterman<T: Coord + std::fmt::Debug>(layout: &mut Layout<T>) {
     let center = &layout.settings.center;
     // 0.01 * k * g
-    let gf = layout.settings.kr.clone() * layout.settings.ka.clone() * layout.settings.kg.clone();
+    let gf = T::from(0.01).unwrap_or_else(T::zero) * layout.settings.ka.clone() * layout.settings.kg.clone();
     for (pos, speed) in izip!(
         layout.points.iter(),
         layout.speeds.iter_mut()
@@ -34,6 +34,7 @@ pub fn apply_gravity_fruchterman<T: Coord + std::fmt::Debug>(layout: &mut Layout
 }
 
 pub fn apply_gravity_forceatlas2<T: Coord + std::fmt::Debug>(layout: &mut Layout<T>) {
+    let center = &layout.settings.center;
     for (mass, pos, speed) in izip!(
         layout.masses.iter(),
         layout.points.iter(),
@@ -44,22 +45,22 @@ pub fn apply_gravity_forceatlas2<T: Coord + std::fmt::Debug>(layout: &mut Layout
             continue;
         }
         let f = (mass.clone() + T::one()) * layout.settings.kg.clone() / d;
-        for (speed, pos) in speed.iter_mut().zip(pos.iter()) {
-            *speed -= f.clone() * pos.clone();
+        for ((index, speed), pos) in speed.iter_mut().enumerate().zip(pos.iter()) {
+            unsafe {*speed -= f.clone() * (pos.clone() - center.get_unchecked(index).clone())};
         }
     }
 }
 
 pub fn apply_gravity_forceatlas2_sg<T: Coord + std::fmt::Debug>(layout: &mut Layout<T>) {
-    
+    let center = &layout.settings.center;
     for (mass, pos, speed) in izip!(
         layout.masses.iter(),
         layout.points.iter(),
         layout.speeds.iter_mut()
     ) {
         let f = (mass.clone() + T::one()) * layout.settings.kg.clone();
-        for (speed, pos) in speed.iter_mut().zip(pos.iter()) {
-            *speed -= f.clone() * pos.clone();
+        for ((index, speed), pos) in speed.iter_mut().enumerate().zip(pos.iter()) {
+            unsafe {*speed -= f.clone() * (pos.clone() - center.get_unchecked(index).clone())};
         }
     }
 }

--- a/packages/layout-rust/src/forces/repulsion.rs
+++ b/packages/layout-rust/src/forces/repulsion.rs
@@ -159,7 +159,6 @@ pub fn apply_repulsion_fruchterman_2d_parallel<T: Copy + Coord + std::fmt::Debug
 ) {
     let k = &layout.settings.ka;
     let k2 = *k * *k;
-    let kr = layout.settings.kr;
     for chunk_iter in layout.iter_par_nodes(layout.settings.chunk_size.unwrap()) {
         chunk_iter.for_each(|n1_iter| {
             for n1 in n1_iter {
@@ -167,7 +166,7 @@ pub fn apply_repulsion_fruchterman_2d_parallel<T: Copy + Coord + std::fmt::Debug
                     let dx = unsafe { *n2.pos.get_unchecked(0) - *n1.pos.get_unchecked(0) };
                     let dy = unsafe { *n2.pos.get_unchecked(1) - *n1.pos.get_unchecked(1) };
 
-                    let d2 = dx * dx + dy * dy + kr.clone();
+                    let d2 = dx * dx + dy * dy + T::from(0.01).unwrap_or_else(T::zero);
                     
                     let param = k2 / d2;
 

--- a/packages/layout-rust/src/layout.rs
+++ b/packages/layout-rust/src/layout.rs
@@ -11,6 +11,16 @@ pub enum LayoutType {
 }
 
 #[derive(Clone)]
+pub enum DistanceThresholdMode {
+    /// Use the average distance between nodes
+    Average,
+    /// Use the maximum distance between nodes
+    Max,
+    /// Use the minimum distance between nodes
+    Min,
+}
+
+#[derive(Clone)]
 pub struct Settings<T: Coord> {
     pub name: LayoutType,
     /// Number of nodes computed by each thread
@@ -57,6 +67,7 @@ pub struct Settings<T: Coord> {
     pub interval: T,
     pub max_speed: T,
     pub min_movement: T,
+    pub distance_threshold_mode: DistanceThresholdMode,
 
     /// Used in Fruchterman layout.
     pub center: Vec<T>,
@@ -86,6 +97,7 @@ impl<T: Coord> Default for Settings<T> {
             center: vec![T::zero(); 2],
             max_speed: T::one(),
             min_movement: T::zero(),
+            distance_threshold_mode: DistanceThresholdMode::Average,
         }
     }
 }

--- a/packages/layout-rust/src/lib.rs
+++ b/packages/layout-rust/src/lib.rs
@@ -12,7 +12,7 @@ mod util;
 
 use forces::{Attraction, Repulsion};
 
-pub use layout::{Layout, LayoutType, Settings};
+pub use layout::{Layout, LayoutType, DistanceThresholdMode, Settings};
 pub use util::{Coord, Edge, Nodes, PointIter, PointIterMut, PointList, Position};
 
 use itertools::izip;
@@ -86,25 +86,56 @@ where
     }
 
     /// Computes an iteration
-    pub fn iteration(&mut self, i: usize) {
+    pub fn iteration(&mut self, i: usize) -> bool {
         self.init_iteration();
         self.apply_attraction();
         self.apply_repulsion();
         self.apply_gravity();
 
+        let mut judging_distance = match self.settings.distance_threshold_mode {
+            DistanceThresholdMode::Average => T::zero(),
+            DistanceThresholdMode::Max => T::from(f32::MIN).unwrap_or_else(T::zero),
+            DistanceThresholdMode::Min => T::from(f32::MAX).unwrap_or_else(T::zero),
+        };
+        let distance_threshold_mode = self.settings.distance_threshold_mode.clone();
+
+        let mut update_judging_distance = |distance| {
+            match distance_threshold_mode {
+                DistanceThresholdMode::Average => {
+                    judging_distance += distance;
+                },
+                DistanceThresholdMode::Max => {
+                    if distance > judging_distance {
+                        judging_distance = distance;
+                    }
+                },
+                DistanceThresholdMode::Min => {
+                    if distance < judging_distance {
+                        judging_distance = distance;
+                    }
+                },
+            }
+        };
+
         match self.settings.name {
             LayoutType::Fruchterman => {
                 let interval = self.settings.interval.clone();
-                self.apply_forces_fruchterman(pow(interval, i));
+                self.apply_forces_fruchterman(pow(interval, i), &mut update_judging_distance);
             },
             LayoutType::Force2 => {
                 let m1 = T::from(0.02).unwrap_or_else(T::one);
                 let m2 = self.settings.interval.clone() - T::from(i).unwrap_or_else(T::one) * T::from(0.002).unwrap_or_else(T::one);
                 let interval = if m1 > m2 { m1 } else { m2 };
-                self.apply_forces_force2(interval);
+                self.apply_forces_force2(interval, &mut update_judging_distance);
             },
-            LayoutType::ForceAtlas2 => self.apply_forces_forceatlas2(),
+            LayoutType::ForceAtlas2 => self.apply_forces_forceatlas2(&mut update_judging_distance),
+        };
+
+        if let DistanceThresholdMode::Average = self.settings.distance_threshold_mode  {
+            judging_distance /= T::from(self.points.points.len() / self.points.dimensions).unwrap_or_else(T::one);
         }
+
+        judging_distance < self.settings.min_movement
     }
 
     fn init_iteration(&mut self) {
@@ -120,16 +151,7 @@ where
                     *speed = T::zero();
                 }
             },
-            LayoutType::Fruchterman => {
-                for speed in self
-                    .speeds
-                    .points
-                    .iter_mut()
-                {
-                    *speed = T::zero();
-                }
-            },
-            LayoutType::Force2 => {
+            _ => {
                 for speed in self
                     .speeds
                     .points
@@ -153,7 +175,7 @@ where
         (self.fn_repulsion)(self)
     }
 
-    fn apply_forces_force2(&mut self, interval: T) {
+    fn apply_forces_force2(&mut self, interval: T, update_judging_distance: &mut impl FnMut(T)) {
         let damping = &self.settings.damping;
         let param = interval.clone() * damping.clone();
         let max_speed = self.settings.max_speed.clone();
@@ -170,7 +192,7 @@ where
 
                 
             pos.iter_mut()
-                .zip(speed.iter_mut())
+                .zip(speed.iter())
                 .for_each(|(pos, speed)| {
                     let mut v = speed.clone() * param.clone();
 
@@ -179,16 +201,18 @@ where
                     }
                     *pos += v * interval.clone();
                 });
+
+            update_judging_distance(dist_length);
         }
     }
 
-    fn apply_forces_fruchterman(&mut self, i: T) {
+    fn apply_forces_fruchterman(&mut self, i: T, update_judging_distance: &mut impl FnMut(T)) {
         let u_speed = &self.settings.speed;
         let max_displace = u_speed.clone() * self.settings.damping.clone() * i.clone();
 
         for (pos, speed) in izip!(
             self.points.iter_mut(),
-            self.speeds.iter_mut(),
+            self.speeds.iter(),
         ) {
             let dist_length = speed
                 .iter()
@@ -196,15 +220,22 @@ where
                 .sum::<T>()
                 .sqrt();
             let limited_dist = if dist_length > max_displace { max_displace.clone() } else { dist_length.clone() };
+
+            let mut distance = T::zero();
             pos.iter_mut()
-                .zip(speed.iter_mut())
+                .zip(speed.iter())
                 .for_each(|(pos, speed)| {
-                    *pos += speed.clone() * u_speed.clone() / dist_length.clone() * limited_dist.clone();
+                    let d = speed.clone() * u_speed.clone() / dist_length.clone() * limited_dist.clone();
+                    distance += d.clone() * d.clone();
+                    *pos += d.clone();
                 });
+            distance = distance.sqrt();
+
+            update_judging_distance(distance);
         }
     }
 
-    fn apply_forces_forceatlas2(&mut self) {
+    fn apply_forces_forceatlas2(&mut self, update_judging_distance: &mut impl FnMut(T)) {
         for (pos, speed, old_speed) in izip!(
             self.points.iter_mut(),
             self.speeds.iter_mut(),
@@ -225,11 +256,17 @@ where
 
             let f = traction.ln_1p() / (swinging.sqrt() + T::one()) * self.settings.speed.clone();
 
+            let mut distance = T::zero();
             pos.iter_mut()
-                .zip(speed.iter_mut())
+                .zip(speed.iter())
                 .for_each(|(pos, speed)| {
-                    *pos += speed.clone() * f.clone();
+                    let d = speed.clone() * f.clone();
+                    distance += d.clone() * d.clone();
+                    *pos += d.clone();
                 });
+            distance = distance.sqrt();
+
+            update_judging_distance(distance);
         }
     }
 }

--- a/packages/layout-wasm/README.md
+++ b/packages/layout-wasm/README.md
@@ -31,18 +31,111 @@ Then we can execute layout algorithm as usual.
 
 ```js
 const { nodes } = await forceatlas2({
-  kg: 1,
+  nodes,
+  edges,
+  masses,
+  weights,
+  iterations,
   // other options
+  kg: 1,
 }); // [x1, y1, x2, y2...]
 ```
 
-## API
+## API Reference
+
+### Shared params
+
+<a name="nodes" href="#nodes">#</a> <b>nodes</b>
+
+A list of nodes' coordinates, e.g. `[x1, y1, x2, y2, ...]`.
+
+<a name="edges" href="#edges">#</a> <b>edges</b>
+
+The specified array of **edges**. Assumes edges `(n1, n2)` respect `n1 < n2`, e.g. `[[n1, n2], [n3, n4], ...]`.
+
+<a name="masses" href="#masses">#</a> <b>masses</b>
+
+A list of masses, e.g. `[m1, m2, ...]`.
+
+<a name="weights" href="#weights">#</a> <b>weights</b>
+
+A list of weights, e.g. `[e1, e2, ...]`.
+
+<a name="iterations" href="#iterations">#</a> <b>iterations</b>
+
+The max number of iterations. If the average movement do not reach minMovement but the iteration number is over maxIteration, terminate the layout.
+
+<a name="distance_threshold_mode" href="#distance_threshold_mode">#</a> <b>distance_threshold_mode</b>
+
+The condition to judge with minMovement:
+
+- 0 -> 'mean' means the layout stops while the nodes' average movement is smaller than minMovement
+- 1 -> 'min' means the layout stops while the nodes' minimum movement is smaller than minMovement
+- 2 -> 'max' means the layout stops while the nodes' maximum movement is smaller than minMovement
+
+<a name="min_movement" href="#min_movement">#</a> <b>min_movement</b>
+
+When the average/minimum/maximum (according to distanceThresholdMode) movement of nodes in one iteration is smaller than minMovement, terminate the layout
 
 ### forceatlas2
 
+<a name="ka" href="#ka">#</a> <b>ka</b>
+
+Attraction coefficient.
+
+<a name="kg" href="#kg">#</a> <b>kg</b>
+
+Gravity coefficient, larger the kg, the graph will be more compact to the center.
+
+<a name="kr" href="#kr">#</a> <b>kr</b>
+
+Repulsion coefficient, smaller the kr, more compact the graph will be.
+
+<a name="speed" href="#speed">#</a> <b>speed</b>
+
+Speed factor.
+
+<a name="strong_gravity" href="#strong_gravity">#</a> <b>strong_gravity</b>
+
+<a name="lin_log" href="#lin_log">#</a> <b>lin_log</b>
+
+<a name="dissuade_hubs" href="#dissuade_hubs">#</a> <b>dissuade_hubs</b>
+
 ### fruchterman
 
+<a name="kg" href="#kg">#</a> <b>kg</b>
+
+Gravity coefficient, larger the kg, the graph will be more compact to the center.
+
+<a name="width" href="#width">#</a> <b>width</b>
+
+<a name="height" href="#height">#</a> <b>height</b>
+
+<a name="speed" href="#speed">#</a> <b>speed</b>
+
+Speed factor.
+
 ### force2
+
+<a name="kg" href="#kg">#</a> <b>kg</b>
+
+Gravity coefficient, larger the kg, the graph will be more compact to the center.
+
+<a name="edge_strength" href="#edge_strength">#</a> <b>edge_strength</b>
+
+<a name="link_distance" href="#link_distance">#</a> <b>link_distance</b>
+
+<a name="node_strength" href="#node_strength">#</a> <b>node_strength</b>
+
+<a name="coulomb_dis_scale" href="#coulomb_dis_scale">#</a> <b>coulomb_dis_scale</b>
+
+<a name="factor" href="#factor">#</a> <b>factor</b>
+
+<a name="damping" href="#damping">#</a> <b>damping</b>
+
+<a name="interval" href="#interval">#</a> <b>interval</b>
+
+<a name="max_speed" href="#max_speed">#</a> <b>max_speed</b>
 
 ## Benchmarks
 

--- a/packages/layout-wasm/src/interface.ts
+++ b/packages/layout-wasm/src/interface.ts
@@ -19,7 +19,6 @@ export interface Forceatlas2LayoutOptions extends ForceLayoutOptions {
   strong_gravity: boolean;
   lin_log: boolean;
   dissuade_hubs: boolean;
-  center: [number, number];
 }
 export interface Force2LayoutOptions extends ForceLayoutOptions {
   edge_strength: number;
@@ -29,28 +28,25 @@ export interface Force2LayoutOptions extends ForceLayoutOptions {
   factor: number;
   interval: number;
   damping: number;
-  center: [number, number];
   kg: number; // gravity
   max_speed: number;
-  min_movement: number;
 }
 
 export interface FruchtermanLayoutOptions extends ForceLayoutOptions {
-  center: [number, number];
-  ka: number; // k
+  height: number; // height
+  width: number; // width
   kg: number; // gravity
-  kr: number; // 0.01
   speed: number; // speed
-  damping: number; // maxDisplace
-  interval: number; // *= maxDisplace 0.99
 }
 
 export interface ForceLayoutOptions {
   // name: number;
-  nodes: number;
+  nodes: number[];
   edges: number[];
   masses: number[];
   weights: number[];
-  positions: number[];
   iterations: number;
+  min_movement: number;
+  distance_threshold_mode: number;
+  center: [number, number];
 }

--- a/site/index.html
+++ b/site/index.html
@@ -9,12 +9,17 @@
       html,
       body {
         margin: 0 !important;
-        padding: 0 !important;
+        padding: 10px !important;
       }
       canvas {
         width: 400px;
         height: 400px;
         border: 1px solid black;
+      }
+      button {
+        height: 30px;
+        width: 100px;
+        margin-top: 10px;
       }
       figure {
         flex: 1 1 25%;
@@ -169,6 +174,29 @@
         <label for="iterations">Iterations:</label>
         <input type="number" id="iterations" name="iterations" value="50" />
       </div>
+      <div>
+        <label for="min_movement">Min movement:</label>
+        <input type="number" id="min_movement" name="min_movement" value="0.4" />
+      </div>
+      <div>
+        <label for="distance_threshold_mode">Distance threshold mode:</label>
+        <select name="distance_threshold_mode" id="distance_threshold_mode">
+          <option value="mean" selected>mean</option>
+          <option value="min">min</option>
+          <option value="max">max</option>
+        </select>
+      </div>
+      <p>
+        Distance threshold mode means the condition to judge with min movement:
+        <ul>
+          <li>
+            'mean' means the layout stops while the nodes' average movement is smaller than min movement
+          </li>
+          <li>
+            'max' / 'min' means the layout stops while the nodes' maximum/minimum movement is smaller than min movement
+          </li>
+        </ul>
+      </p>
     </fieldset>
 
     <fieldset>

--- a/site/main.ts
+++ b/site/main.ts
@@ -42,6 +42,12 @@ const TestsConfig = [
 
 const $mask = document.getElementById("mask") as HTMLSelectElement;
 const $iterations = document.getElementById("iterations") as HTMLInputElement;
+const $min_movement = document.getElementById(
+  "min_movement"
+) as HTMLInputElement;
+const $distance_threshold_mode = document.getElementById(
+  "distance_threshold_mode"
+) as HTMLInputElement;
 const $dataset = document.getElementById("dataset") as HTMLSelectElement;
 const $datasetDesc = document.getElementById("dataset-desc") as HTMLSpanElement;
 const $layout = document.getElementById("layout") as HTMLSelectElement;
@@ -71,12 +77,17 @@ const initThreads = async () => {
   return [singleThread, multiThreads];
 };
 
+export type CommonLayoutOptions = {
+  iterations: number;
+  min_movement: number;
+  distance_threshold_mode: "mean" | "max" | "min";
+};
 const doLayout = async (
   context: CanvasRenderingContext2D,
   $label: HTMLSpanElement,
   layout: any,
   model: any,
-  options: any,
+  options: CommonLayoutOptions,
   wasmMethod: any
 ) => {
   const start = performance.now();
@@ -154,6 +165,11 @@ const doLayout = async (
             dataset[name],
             {
               iterations: parseInt($iterations.value),
+              min_movement: parseFloat($min_movement.value),
+              distance_threshold_mode: $distance_threshold_mode.value as
+                | "mean"
+                | "max"
+                | "min",
             },
             name === TestName.ANTV_LAYOUT_WASM_MULTITHREADS
               ? forceMultiThreads

--- a/site/util.ts
+++ b/site/util.ts
@@ -61,3 +61,11 @@ export function outputAntvLayoutWASM(
 
   return { nodes, edges: outputEdges };
 }
+
+export function distanceThresholdMode(mode: string): number {
+  return {
+    mean: 0,
+    min: 1,
+    max: 2,
+  }[mode];
+}


### PR DESCRIPTION
增加了 min_movement 和 distance_threshold_mode 两个参数，作为力导布局的公共配置项，用于满足条件时提前终止迭代。
这样 WASM 版本会快很多，主要避免了收敛之后的无效计算。

<img width="1738" alt="截屏2023-04-27 下午3 18 02" src="https://user-images.githubusercontent.com/3608471/234788264-180b9795-f8c7-47ab-8644-b313f7c17ccf.png">
