### PR TITLE
fix: innerNode is undefined

### DIFF
--- a/src/layout/comboCombined.ts
+++ b/src/layout/comboCombined.ts
@@ -120,6 +120,9 @@ export class ComboCombinedLayout extends Base {
     let allHaveNoPosition = true;
     this.comboTrees.forEach((cTree) => {
       const innerNode = innerGraphs[cTree.id];
+      if (!innerNode) {
+        return;
+      }
       // 代表 combo 的节点
       const oNode: Node = {
         ...cTree,


### PR DESCRIPTION
Fix this error when trying to rearrange (layout) graph with empty combo.