### PR TITLE
fix: common util func handleSingleNodeGraph

### DIFF
--- a/packages/layout/src/util/common.ts
+++ b/packages/layout/src/util/common.ts
@@ -12,7 +12,7 @@ export const handleSingleNodeGraph = (
   assign: boolean,
   center: PointTuple,
 ) => {
-  const nodes = graph.getAllNodes();
+  const nodes = graph.getAllNodes().filter((node) => !node.data._isCombo);
   const edges = graph.getAllEdges();
   if (!nodes?.length) {
     const result = { nodes: [] as any[], edges };


### PR DESCRIPTION
`comboCombined` 调用 `handleSingleNodeGraph` 函数的前提是: 移除了 `_isCombo` 状态的 `nodes` 的个数 <= 1

https://github.com/antvis/layout/blob/3a70d6314865a8ebb0f9750787e491e74bbeac26/packages/layout/src/comboCombined.ts#L93-L104

但是 `handleSingleNodeGraph` 函数内部处理时, 获取到的是包含 `_isCombo` 状态的 `nodes`.

https://github.com/antvis/layout/blob/3a70d6314865a8ebb0f9750787e491e74bbeac26/packages/layout/src/util/common.ts#L10-L43

这会导致使用 `combo-combined` 布局时, 存在某些异常->`handleSingleNodeGraph` 函数返回 `undefined`, 异常数据如下所示:

```
{
  nodes: [{id: 'node1'}, {id: 'node2', combo: 'combo1'}, {id: 'node3', combo: 'combo1'}],
  combos: [{id: 'combo1'}],
}
```

