### PR TITLE
fix: source files not included

### DIFF
--- a/packages/layout-gpu/package.json
+++ b/packages/layout-gpu/package.json
@@ -13,6 +13,7 @@
   "types": "lib/index.d.ts",
   "unpkg": "dist/index.min.js",
   "files": [
+    "src",
     "package.json",
     "dist",
     "lib",

--- a/packages/layout-wasm/package.json
+++ b/packages/layout-wasm/package.json
@@ -13,6 +13,7 @@
   "types": "lib/index.d.ts",
   "unpkg": "dist/index.min.js",
   "files": [
+    "src",
     "package.json",
     "dist",
     "lib",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -13,6 +13,7 @@
   "types": "lib/index.d.ts",
   "unpkg": "dist/index.min.js",
   "files": [
+    "src",
     "package.json",
     "dist",
     "lib",


### PR DESCRIPTION
Similar to https://github.com/antvis/util/pull/125, the source files are not in the published packages.