### PR TITLE
chore(build): switch to Webpack for ESM build

### DIFF
--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -60,7 +60,7 @@
     "dev": "webpack --config webpack.dev.config.js --mode development",
     "build": "npm run clean && run-p build:*",
     "ci": "npm run build && npm run test",
-    "build:esm": "tsc",
+    "build:esm": "webpack --config webpack.esm.config.js --mode production",
     "build:umd": "webpack --config webpack.config.js --mode production",
     "publish:alpha": "npm publish --tag alpha",
     "test": "jest",

--- a/packages/layout/tsconfig.json
+++ b/packages/layout/tsconfig.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
+    "types": [],
     "experimentalDecorators": false /* Enables experimental support for ES7 decorators. */,
     // "emitDecoratorMetadata": true, /* Enables experimental support for emitting type metadata for decorators. */
     "downlevelIteration": true,

--- a/packages/layout/webpack.esm.config.js
+++ b/packages/layout/webpack.esm.config.js
@@ -1,0 +1,30 @@
+const path = require("path");
+
+module.exports = {
+  entry: "./src/bundle-entry.ts",
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    filename: "index.js",
+    publicPath: "",
+    path: path.resolve(__dirname, "lib"),
+    library: {
+      type: "module",
+    },
+    clean: true,
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  devtool: "source-map",
+};


### PR DESCRIPTION
在使用 `tsc` 打包 ESM 时，`worker` 文件没有被正确定位，Web Worker 处于不可用状态。UMD 用的 webpack 打包，功能正常可用。

分析下来，`tsc` 仅做类型编译和文件转换，不会处理 `import.meta.url` 或内联的 Worker 资源路径，因此无法生成独立的 worker bundle。

这里把 ESM 的打包方式也改成 webpack。